### PR TITLE
feat(amis-admin): 记住 CRUD 分页大小

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
+    env:
+      COMPOSER_ROOT_VERSION: dev-main
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/packages/amis-admin/src/view/_amis-basic.php
+++ b/packages/amis-admin/src/view/_amis-basic.php
@@ -5,6 +5,7 @@
 /** @var string|null $script */
 
 $debug = $assets['debug'] ?? false;
+$crudPerPageScript = file_get_contents(__DIR__ . '/amis-crud-per-page.js');
 ?>
 <!DOCTYPE html>
 <html lang="<?= $assets['lang'] ?? 'zh' ?>">
@@ -41,10 +42,13 @@ $debug = $assets['debug'] ?? false;
 <script type="text/javascript">
   (function () {
     <?= $script ?? '' ?>
+    <?= $crudPerPageScript ?>
 
     const amis = amisRequire('amis/embed');
+    const amisLib = amisRequire('amis');
 
     window.amisAppBeforeLoad && window.amisAppBeforeLoad(amis);
+    initCrudPerPagePersistence(amisLib);
 
     const amisJSON = <?= json_encode($amisJSON, $debug ? JSON_PRETTY_PRINT : JSON_ERROR_NONE) ?>;
     window.amisApp = amis.embed(

--- a/packages/amis-admin/src/view/amis-crud-per-page.js
+++ b/packages/amis-admin/src/view/amis-crud-per-page.js
@@ -1,0 +1,90 @@
+function initCrudPerPagePersistence(amisLib) {
+  if (window.__amisCrudPerPagePersistencePatched) {
+    return;
+  }
+
+  try {
+    const proto = amisLib?.getRendererByName?.('crud')?.Renderer?.prototype;
+    if (!proto || proto.__crudPerPagePersistencePatched) {
+      window.__amisCrudPerPagePersistencePatched = true;
+      return;
+    }
+
+    const getStorageKey = () => {
+      const route = String(window.location.hash || '').split('?')[0] || window.location.pathname || 'default';
+      return `amis_admin:crud_per_page:route:${encodeURIComponent(route)}`;
+    };
+
+    const getSavedPerPage = () => {
+      try {
+        const value = Number.parseInt(window.localStorage?.getItem(getStorageKey()) || '', 10);
+        return value > 0 ? value : null;
+      } catch (error) {
+        return null;
+      }
+    };
+
+    const hasPerPageInLocation = (field) => {
+      const sources = [window.location.search || '', String(window.location.hash || '').split('?')[1] || ''];
+      return sources.some((query) => {
+        try {
+          return new URLSearchParams(query).has(field);
+        } catch (error) {
+          return false;
+        }
+      });
+    };
+
+    const persistPerPage = (value, defaultValue) => {
+      if (!(value > 0)) {
+        return;
+      }
+
+      try {
+        const storageKey = getStorageKey();
+        if (defaultValue > 0 && value === defaultValue) {
+          window.localStorage?.removeItem(storageKey);
+          return;
+        }
+
+        window.localStorage?.setItem(storageKey, String(value));
+      } catch (error) {}
+    };
+
+    const originalDidMount = typeof proto.componentDidMount === 'function' ? proto.componentDidMount : null;
+    const originalHandleChangePage = typeof proto.handleChangePage === 'function' ? proto.handleChangePage : null;
+
+    proto.componentDidMount = function (...args) {
+      try {
+        originalDidMount?.apply(this, args);
+
+        const field = this.props?.perPageField || 'perPage';
+        const currentPerPage = Number(this.props?.store?.query?.[field] || this.props?.store?.perPage || this.props?.perPage || 0);
+        this.__crudPerPageDefault = Number(this.props?.store?.perPage || this.props?.perPage || 0);
+
+        const savedPerPage = getSavedPerPage();
+        if (savedPerPage && !hasPerPageInLocation(field) && savedPerPage !== currentPerPage) {
+          this.handleChangePage?.(1, savedPerPage);
+        }
+      } catch (error) {}
+    };
+
+    proto.handleChangePage = async function (page, perPage, dir) {
+      if (!originalHandleChangePage) {
+        return;
+      }
+
+      const result = await originalHandleChangePage.call(this, page, perPage, dir);
+
+      // 仅在 amis 原始分页成功后再同步存储；持久化失败时只降级，不影响列表渲染。
+      persistPerPage(Number(perPage || this.props?.store?.perPage || 0), Number(this.__crudPerPageDefault || 0));
+
+      return result;
+    };
+
+    proto.__crudPerPagePersistencePatched = true;
+    window.__amisCrudPerPagePersistencePatched = true;
+  } catch (error) {
+    window.__amisCrudPerPagePersistencePatched = true;
+  }
+}


### PR DESCRIPTION
## 变更说明
- 为 amis-admin 的 CRUD 列表增加分页大小记忆能力
- 通过独立前端脚本在运行时补丁 amis crud 渲染器
- 当用户切回默认分页大小时自动删除本地存储
- 增加防御性兜底，amis API 变化时仅降级失效，不影响页面渲染

## 验证方式
- 切换列表分页大小后刷新页面，确认分页大小仍然生效
- 切换菜单离开后返回，确认分页大小仍然生效
- 切回默认值后，确认对应 localStorage key 被删除

Closes #4