### PR TITLE
feat(swagger): 支持 Basic Auth 认证和自定义中间件

### DIFF
--- a/packages/swagger/AGENTS.md
+++ b/packages/swagger/AGENTS.md
@@ -6,7 +6,7 @@
 - **零配置启动**：安装后直接访问 `/openapi` 即可看到 Swagger UI
 - **多文档支持**：单应用下多个 Swagger 文档
 - **动态配置**：动态修改注解下的 Swagger 文档
-- **丰富配置**：host 限制、Swagger UI 配置、OpenAPI 配置
+- **丰富配置**：host 限制、Swagger UI 配置、OpenAPI 配置、自定义中间件（auth 等）
 - **性能优化**：服务启动后缓存，开发环境自动更新
 - **路由自动注册**：支持自动注册 webman 路由
 - **跨框架兼容**：不仅仅支持 webman
@@ -25,10 +25,10 @@
   - `Overwrite/`：覆盖 swagger-php 默认行为（Generator/Analysis/ReflectionAnalyser/Processors/Analysers）
   - `Controller/`：
     - `OpenapiController.php`：提供 OpenAPI JSON 及 Swagger UI 页面
-  - `DTO/`：各配置 DTO（OpenapiDoc/SwaggerUi/HostForbidden/RegisterRoute）
+  - `DTO/`：各配置 DTO（OpenapiDoc/SwaggerUi/HostForbidden/BasicAuth/RegisterRoute）
   - `Enums/`：PropertyInEnum
   - `Helper/`：SwaggerHelper/ConfigHelper/ArrayHelper/JsExpression
-  - `Middleware/`：HostForbiddenMiddleware
+  - `Middleware/`：HostForbiddenMiddleware、BasicAuthMiddleware
   - `view/`：swagger-ui.php 视图模板
 - `copy/`：配置文件模板
 - `skills/`：AI 技能

--- a/packages/swagger/README.md
+++ b/packages/swagger/README.md
@@ -34,7 +34,11 @@ composer require webman-tech/swagger
 
 #### ConfigRegisterRouteDTO
 
-路由注册配置，控制路由注册行为，包含启用开关（`enable`）、路由前缀（`route_prefix`）、访问权限控制（`host_forbidden`）、Swagger UI 配置（`swagger_ui`）、OpenAPI 文档配置（`openapi_doc`）及是否注册 webman 路由（`register_route`）。
+路由注册配置，控制路由注册行为，包含启用开关（`enable`）、路由前缀（`route_prefix`）、访问权限控制（`host_forbidden`）、Basic 认证（`basic_auth`）、Swagger UI 配置（`swagger_ui`）、OpenAPI 文档配置（`openapi_doc`）、是否注册 webman 路由（`register_route`）及额外中间件（`middlewares`）。
+
+#### ConfigBasicAuthDTO
+
+Basic 认证配置，默认关闭。启用后访问 Swagger UI 和 OpenAPI 文档时需要提供用户名和密码。支持配置用户名（`username`）、密码（`password`）和认证提示域（`realm`）。
 
 #### ConfigOpenapiDocDTO
 

--- a/packages/swagger/copy/config/plugin/app.php
+++ b/packages/swagger/copy/config/plugin/app.php
@@ -12,6 +12,11 @@ return [
     'global_route' => [
         'enable' => true,
         'register_route' => false,
+        /**
+         * 额外的中间件，可用于添加 auth 认证等
+         * @see \WebmanTech\Swagger\DTO\ConfigRegisterRouteDTO::$middlewares
+         */
+        'middlewares' => [],
     ],
     /**
      * 全局的 host forbidden 配置
@@ -20,6 +25,15 @@ return [
     'host_forbidden' => [
         'enable' => true,
         'host_white_list' => [],
+    ],
+    /**
+     * 全局的 Basic Auth 配置
+     * @see \WebmanTech\Swagger\DTO\ConfigBasicAuthDTO
+     */
+    'basic_auth' => [
+        'enable' => false,
+        'username' => '',
+        'password' => '',
     ],
     /**
      * 全局的 swagger ui 配置

--- a/packages/swagger/skills/webman-tech-swagger-best-practices/SKILL.md
+++ b/packages/swagger/skills/webman-tech-swagger-best-practices/SKILL.md
@@ -37,6 +37,9 @@ final class SwaggerRegister
             'swagger_ui' => [
                 'tag_sort' => ['认证', '用户', '订单'],  // 控制 Tag 在 UI 中的排序
             ],
+            'basic_auth' => [
+                'enable' => false,     
+            ],
             'openapi_doc' => [
                 'scan_path' => fn() => [
                     Finder::create()->files()->name('*.php')
@@ -326,6 +329,8 @@ enum StatusEnum: string
 
 ## 安全配置
 
+### IP/Host 限制
+
 生产环境禁止外网访问文档：
 
 ```php
@@ -334,6 +339,46 @@ enum StatusEnum: string
     'ip_white_list_intranet' => true,  // 允许所有内网 IP
     'ip_white_list' => ['1.2.3.4'],    // 额外允许的 IP
     'host_white_list' => ['admin.example.com'],  // 允许的 host
+],
+```
+
+### Basic 认证
+
+需要用户名密码才能访问 Swagger UI：
+
+```php
+// config/plugin/webman-tech/swagger/app.php
+'basic_auth' => [
+    'enable' => true,
+    'username' => 'admin',
+    'password' => 'your-secure-password',
+    'realm' => 'API Documentation',  // 可选，认证提示信息
+],
+```
+
+也可以在 `registerRoute` 时通过 `global_route` 配置：
+
+```php
+'global_route' => [
+    'basic_auth' => [
+        'enable' => true,
+        'username' => 'admin',
+        'password' => 'secret',
+    ],
+],
+```
+
+两种安全机制（IP 限制 + Basic Auth）可以同时启用，按顺序执行。
+
+### 自定义中间件
+
+如需更复杂的认证（如基于 auth 包的登录认证），通过 `middlewares` 配置：
+
+```php
+'global_route' => [
+    'middlewares' => [
+        new \WebmanTech\Auth\Middleware\Authentication('admin'),
+    ],
 ],
 ```
 

--- a/packages/swagger/src/DTO/ConfigBasicAuthDTO.php
+++ b/packages/swagger/src/DTO/ConfigBasicAuthDTO.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WebmanTech\Swagger\DTO;
+
+use WebmanTech\DTO\BaseConfigDTO;
+
+final class ConfigBasicAuthDTO extends BaseConfigDTO
+{
+    public function __construct(
+        public bool   $enable = false,
+        public string $username = '',
+        public string $password = '',
+        public string $realm = 'Swagger API Documentation',
+    )
+    {
+    }
+}

--- a/packages/swagger/src/DTO/ConfigRegisterRouteDTO.php
+++ b/packages/swagger/src/DTO/ConfigRegisterRouteDTO.php
@@ -3,27 +3,45 @@
 namespace WebmanTech\Swagger\DTO;
 
 use WebmanTech\DTO\BaseConfigDTO;
+use WebmanTech\Swagger\Middleware\BasicAuthMiddleware;
+use WebmanTech\Swagger\Middleware\HostForbiddenMiddleware;
 
 final class ConfigRegisterRouteDTO extends BaseConfigDTO
 {
     public ConfigHostForbiddenDTO $host_forbidden;
+    public ConfigBasicAuthDTO $basic_auth;
     public ConfigSwaggerUiDTO $swagger_ui;
     public ConfigOpenapiDocDTO $openapi_doc;
     public bool $register_route;
+
+    /**
+     * @var array<int, object|string> 路由中间件列表
+     */
+    public array $middlewares;
 
     public function __construct(
         public bool                       $enable = true, // 是否启用
         public string                     $route_prefix = '/openapi', // openapi 文档的路由前缀
         null|array|ConfigHostForbiddenDTO $host_forbidden = null, // 允许访问的 host
+        null|array|ConfigBasicAuthDTO     $basic_auth = null, // Basic 认证配置
         null|array|ConfigSwaggerUiDTO     $swagger_ui = null, // swagger ui 的配置
         null|array|ConfigOpenapiDocDTO    $openapi_doc = null, // openapi 文档的配置
         bool|null                         $register_webman_route = null, // 是否注册 webman 的路由（弃用，请使用 register_route）
         bool|null                         $register_route = null, // 是否注册路由
+        array                             $middlewares = [], // 额外的中间件（如 auth 认证中间件）
     )
     {
         $this->host_forbidden = ConfigHostForbiddenDTO::fromConfig($host_forbidden ?? []);
+        $this->basic_auth = ConfigBasicAuthDTO::fromConfig($basic_auth ?? []);
         $this->swagger_ui = ConfigSwaggerUiDTO::fromConfig($swagger_ui ?? []);
         $this->openapi_doc = ConfigOpenapiDocDTO::fromConfig($openapi_doc ?? []);
         $this->register_route = $register_route ?? $register_webman_route ?? false;
+        $this->middlewares = array_merge(
+            [
+                new HostForbiddenMiddleware($this->host_forbidden),
+                new BasicAuthMiddleware($this->basic_auth),
+            ],
+            $middlewares,
+        );
     }
 }

--- a/packages/swagger/src/Middleware/BasicAuthMiddleware.php
+++ b/packages/swagger/src/Middleware/BasicAuthMiddleware.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WebmanTech\Swagger\Middleware;
+
+use WebmanTech\CommonUtils\Middleware\BaseMiddleware;
+use WebmanTech\CommonUtils\Request;
+use WebmanTech\CommonUtils\Response;
+use WebmanTech\Swagger\DTO\ConfigBasicAuthDTO;
+
+class BasicAuthMiddleware extends BaseMiddleware
+{
+    protected ConfigBasicAuthDTO $config;
+
+    public function __construct(
+        array|ConfigBasicAuthDTO $config = []
+    )
+    {
+        $this->config = ConfigBasicAuthDTO::fromConfig($config);
+    }
+
+    public function processRequest(Request $request, \Closure $handler): Response
+    {
+        if ($this->config->enable) {
+            $authHeader = $request->header('authorization') ?? '';
+            if (!$this->checkCredentials($authHeader)) {
+                return Response::make()
+                    ->withStatus(401)
+                    ->withHeaders(['WWW-Authenticate' => 'Basic realm="' . $this->config->realm . '"'])
+                    ->withBody('Unauthorized');
+            }
+        }
+
+        return $handler($request);
+    }
+
+    private function checkCredentials(string $authHeader): bool
+    {
+        if (!str_starts_with($authHeader, 'Basic ')) {
+            return false;
+        }
+
+        $decoded = base64_decode(substr($authHeader, 6), true);
+        if ($decoded === false) {
+            return false;
+        }
+
+        $colonPos = strpos($decoded, ':');
+        if ($colonPos === false) {
+            return false;
+        }
+
+        $username = substr($decoded, 0, $colonPos);
+        $password = substr($decoded, $colonPos + 1);
+
+        return $username === $this->config->username && $password === $this->config->password;
+    }
+}

--- a/packages/swagger/src/Swagger.php
+++ b/packages/swagger/src/Swagger.php
@@ -6,7 +6,6 @@ use WebmanTech\CommonUtils\Route;
 use WebmanTech\Swagger\Controller\OpenapiController;
 use WebmanTech\Swagger\DTO\ConfigRegisterRouteDTO;
 use WebmanTech\Swagger\Helper\ConfigHelper;
-use WebmanTech\Swagger\Middleware\HostForbiddenMiddleware;
 use WebmanTech\Swagger\RouteAnnotation\Reader;
 use function WebmanTech\CommonUtils\app_path;
 
@@ -43,7 +42,7 @@ final class Swagger
             throw new \InvalidArgumentException('openapi_doc.scan_path is required');
         }
 
-        $hostForbiddenMiddleware = new HostForbiddenMiddleware($config->host_forbidden);
+        $middlewares = $config->middlewares;
         $controller = new OpenapiController();
 
         $swaggerRoute = $config->route_prefix;
@@ -64,7 +63,7 @@ final class Swagger
                 $dtoGeneratorRoute,
                 fn() => $controller->dtoGenerator($dtoGeneratorConfig),
                 name: $routeName,
-                middlewares: $hostForbiddenMiddleware,
+                middlewares: $middlewares,
             ));
             if ($url = $routerRegister->getRouteByName($routeName)->getUrl(appendPrefix: true)) {
                 $config->swagger_ui->data['dto_generator_url'] = $url;
@@ -76,14 +75,14 @@ final class Swagger
             'GET',
             $swaggerRoute,
             fn() => $controller->swaggerUI($docUrl, $config->swagger_ui),
-            middlewares: $hostForbiddenMiddleware
+            middlewares: $middlewares
         ));
         // 注册 openapi doc 的路由
         $routerRegister->addRoute(new Route\RouteObject(
             'GET',
             $docRoute,
             fn() => $controller->openapiDoc($config->openapi_doc),
-            middlewares: $hostForbiddenMiddleware
+            middlewares: $middlewares
         ));
 
         // 注册 api 接口路由

--- a/tests/Unit/Swagger/MiddlewareTest.php
+++ b/tests/Unit/Swagger/MiddlewareTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use WebmanTech\CommonUtils\Response;
+use WebmanTech\Swagger\Middleware\BasicAuthMiddleware;
 use WebmanTech\Swagger\Middleware\HostForbiddenMiddleware;
 
 test('HostForbiddenMiddleware check', function () {
@@ -100,4 +101,55 @@ test('HostForbiddenMiddleware check', function () {
     $response = $middleware->process($request, fn() => response('ok'));
     expect($response->getStatusCode())->toBe(403);
     expect($response->getBody())->toBe('Access Denied');
+});
+
+test('BasicAuthMiddleware check', function () {
+    $request = request_create_one();
+    $rawRequest = request_get_raw($request);
+
+    // 关闭时不拦截
+    $middleware = new BasicAuthMiddleware(['enable' => false]);
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getStatusCode())->toBe(200);
+
+    // 开启但未传 Authorization
+    $middleware = new BasicAuthMiddleware([
+        'enable' => true,
+        'username' => 'admin',
+        'password' => 'secret',
+    ]);
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getStatusCode())->toBe(401);
+    expect($response->getHeader('WWW-Authenticate'))->toBe('Basic realm="Swagger API Documentation"');
+
+    // 正确的凭证
+    $rawRequest->setHeader('authorization', 'Basic ' . base64_encode('admin:secret'));
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getStatusCode())->toBe(200);
+
+    // 错误的用户名
+    $rawRequest->setHeader('authorization', 'Basic ' . base64_encode('wrong:secret'));
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getStatusCode())->toBe(401);
+
+    // 错误的密码
+    $rawRequest->setHeader('authorization', 'Basic ' . base64_encode('admin:wrong'));
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getStatusCode())->toBe(401);
+
+    // 非 Basic 的 Authorization header
+    $rawRequest->setHeader('authorization', 'Bearer sometoken');
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getStatusCode())->toBe(401);
+
+    // 自定义 realm
+    $middleware = new BasicAuthMiddleware([
+        'enable' => true,
+        'username' => 'admin',
+        'password' => 'secret',
+        'realm' => 'My API Docs',
+    ]);
+    $rawRequest->setHeader('authorization', '');
+    $response = $middleware->processRequest($request, fn() => Response::make()->withBody('ok'));
+    expect($response->getHeader('WWW-Authenticate'))->toBe('Basic realm="My API Docs"');
 });

--- a/tests/Unit/Swagger/SwaggerTest.php
+++ b/tests/Unit/Swagger/SwaggerTest.php
@@ -1,7 +1,10 @@
 <?php
 
 use WebmanTech\CommonUtils\Route;
+use WebmanTech\Swagger\DTO\ConfigRegisterRouteDTO;
 use WebmanTech\Swagger\Helper\ConfigHelper;
+use WebmanTech\Swagger\Middleware\BasicAuthMiddleware;
+use WebmanTech\Swagger\Middleware\HostForbiddenMiddleware;
 use WebmanTech\Swagger\Swagger;
 
 test('registerGlobalRoute dont regsiter_webman_route', function () {
@@ -49,6 +52,77 @@ test('registerGlobalRoute register_webman_route', function () {
     }
     $data = collect($data)->sortBy(fn(array $item) => $item['path'])->values()->toArray(); // 排个序，防止顺序问题
     expect($data)->toMatchSnapshot();
+
+    ConfigHelper::setForTest();
+});
+
+test('ConfigRegisterRouteDTO middlewares default includes HostForbidden and BasicAuth', function () {
+    $config = ConfigRegisterRouteDTO::fromConfig([]);
+
+    expect($config->middlewares)->toHaveCount(2);
+    expect($config->middlewares[0])->toBeInstanceOf(HostForbiddenMiddleware::class);
+    expect($config->middlewares[1])->toBeInstanceOf(BasicAuthMiddleware::class);
+});
+
+test('ConfigRegisterRouteDTO middlewares merges with custom middlewares', function () {
+    $customMiddleware = new class {};
+
+    $config = ConfigRegisterRouteDTO::fromConfig([
+        'middlewares' => [$customMiddleware],
+    ]);
+
+    expect($config->middlewares)->toHaveCount(3);
+    expect($config->middlewares[0])->toBeInstanceOf(HostForbiddenMiddleware::class);
+    expect($config->middlewares[1])->toBeInstanceOf(BasicAuthMiddleware::class);
+    expect($config->middlewares[2])->toBe($customMiddleware);
+});
+
+test('ConfigRegisterRouteDTO basic_auth config passed to BasicAuthMiddleware', function () {
+    $config = ConfigRegisterRouteDTO::fromConfig([
+        'basic_auth' => [
+            'enable' => true,
+            'username' => 'admin',
+            'password' => 'secret',
+        ],
+    ]);
+
+    $basicAuthMiddleware = array_filter($config->middlewares, fn($m) => $m instanceof BasicAuthMiddleware);
+    expect($basicAuthMiddleware)->toHaveCount(1);
+
+    // 验证 basic_auth 配置生效
+    expect($config->basic_auth->enable)->toBeTrue();
+    expect($config->basic_auth->username)->toBe('admin');
+    expect($config->basic_auth->password)->toBe('secret');
+});
+
+test('ConfigRegisterRouteDTO middlewares applied to registered routes', function () {
+    $customMiddleware = new class {};
+    ConfigHelper::setForTest('app.global_route', [
+        'middlewares' => [$customMiddleware],
+        'openapi_doc' => [
+            'scan_path' => [fixture_get_path('Swagger/ControllerForSwagger')],
+        ],
+    ]);
+
+    Route::clear();
+    $route = Route::getCurrent();
+
+    Swagger::create()->registerGlobalRoute();
+
+    // 验证 swagger UI 路由包含了所有中间件
+    $swaggerUiRoute = null;
+    foreach ($route->getRoutes() as $r) {
+        if ($r->getPath() === '/openapi') {
+            $swaggerUiRoute = $r;
+            break;
+        }
+    }
+    expect($swaggerUiRoute)->not->toBeNull();
+    $middlewares = $swaggerUiRoute->getMiddlewares();
+    expect($middlewares)->toHaveCount(3);
+    expect($middlewares[0])->toBeInstanceOf(HostForbiddenMiddleware::class);
+    expect($middlewares[1])->toBeInstanceOf(BasicAuthMiddleware::class);
+    expect($middlewares[2])->toBe($customMiddleware);
 
     ConfigHelper::setForTest();
 });


### PR DESCRIPTION
## Summary

Closes #14

### 新增 BasicAuthMiddleware

- 新增 `BasicAuthMiddleware` + `ConfigBasicAuthDTO`，与 `HostForbiddenMiddleware` 同级
- 默认关闭，启用后访问 Swagger UI 和 OpenAPI 文档需要 Basic 认证
- 支持配置 `username`、`password`、`realm`

### 重构中间件注入机制

- 将 `HostForbiddenMiddleware` 和 `BasicAuthMiddleware` 统一纳入 `ConfigRegisterRouteDTO.middlewares` 数组
- `Swagger::registerRoute()` 不再感知中间件构建细节，直接使用 `$config->middlewares`
- 支持通过 `middlewares` 配置项添加自定义中间件（如 auth 包的认证中间件）

### 配置示例

```php
// Basic Auth
'basic_auth' => [
    'enable' => true,
    'username' => 'admin',
    'password' => 'secret',
],

// 自定义中间件
'global_route' => [
    'middlewares' => [
        new \WebmanTech\Auth\Middleware\Authentication('admin'),
    ],
],
```

### 测试

- 新增 `BasicAuthMiddleware` 单元测试（enable/disable、正确/错误凭证、自定义 realm）
- 新增 `ConfigRegisterRouteDTO.middlewares` 配置测试（默认中间件、自定义中间件合并、路由中间件应用）