### PR TITLE
fix(debugbar): 修复主动初始化未使用数据库连接

### DIFF
--- a/packages/debugbar/src/Bootstrap/LaravelQuery.php
+++ b/packages/debugbar/src/Bootstrap/LaravelQuery.php
@@ -3,29 +3,26 @@
 namespace WebmanTech\Debugbar\Bootstrap;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use support\Db;
+use Throwable;
 use Webman\Bootstrap;
 use WebmanTech\Debugbar\DataCollector\LaravelQueryCollector;
 use WebmanTech\Debugbar\DebugBar;
 
 class LaravelQuery implements Bootstrap
 {
+    private static bool $registered = false;
+
     /**
      * @inheritDoc
      */
     public static function start($worker)
     {
-        if (!class_exists(Capsule::class)) {
+        if (!class_exists(Capsule::class) || !class_exists(Db::class)) {
             return;
         }
-        $connections = array_keys((array)config('database.connections', []));
-        if ($default = config('database.default')) {
-            $connections[] = $default;
-        }
-        if (!$connections) {
-            return;
-        }
-        $connections = array_unique($connections);
 
         $collectorName = (new LaravelQueryCollector())->getName();
         $debugBar = DebugBar::instance();
@@ -36,8 +33,30 @@ class LaravelQuery implements Bootstrap
         /** @var LaravelQueryCollector $collector */
         $collector = $debugBar->getCollector($collectorName);
 
-        foreach ($connections as $connection) {
-            $collector->addListener(Db::connection((string)$connection));
+        self::listenForQueryEvents($collector);
+    }
+
+    private static function listenForQueryEvents(LaravelQueryCollector $collector): void
+    {
+        if (self::$registered) {
+            return;
+        }
+
+        $container = Container::getInstance();
+        if (!$container->bound('events')) {
+            return;
+        }
+
+        $dispatcher = $container->make('events');
+        if (!$dispatcher instanceof Dispatcher) {
+            return;
+        }
+
+        try {
+            $collector->addEventDispatcherListener($dispatcher);
+            self::$registered = true;
+        } catch (Throwable) {
+            // Ignore debug collector listener registration errors.
         }
     }
 }

--- a/packages/debugbar/src/DataCollector/LaravelQueryCollector.php
+++ b/packages/debugbar/src/DataCollector/LaravelQueryCollector.php
@@ -3,6 +3,7 @@
 namespace WebmanTech\Debugbar\DataCollector;
 
 use DebugBar\DataCollector\TimeDataCollector as DebugBarTimeDataCollector;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Events\TransactionBeginning;
@@ -149,67 +150,89 @@ class LaravelQueryCollector extends QueryCollector
             return;
         }
 
-        $event->listen(function (QueryExecuted $event) use ($db): void {
-            $connection = $event->connection;
-            if (!$this->isEventConnectionEqual($db, $connection)) {
-                return;
-            }
-            $bindings = $event->bindings;
-            $time = $event->time;
-            $query = $event->sql;
+        $this->addEventListeners($event, $db);
+    }
 
-            $threshold = $this->config['slow_threshold'];
-            if (!$threshold || $time > $threshold) {
-                if ($collector = $this->getRequestThisCollector()) {
-                    $collector->addQuery($query, $bindings, $time, $connection);
-                }
-            }
+    public function addEventDispatcherListener(Dispatcher $event): void
+    {
+        $this->addEventListeners($event);
+    }
+
+    private function addEventListeners(Dispatcher $event, ?Connection $connection = null): void
+    {
+        $event->listen(function (QueryExecuted $event) use ($connection): void {
+            $this->collectQueryEvent($event, $connection);
         });
 
-        $event->listen(TransactionBeginning::class, function (TransactionBeginning $transaction) use ($db): void {
-            if (!$this->isEventConnectionEqual($db, $transaction->connection)) {
-                return;
-            }
-            if ($collector = $this->getRequestThisCollector()) {
-                $collector->collectTransactionEvent('Begin Transaction', $transaction->connection);
-            }
+        $event->listen(TransactionBeginning::class, function (TransactionBeginning $transaction) use ($connection): void {
+            $this->collectTransactionConnectionEvent('Begin Transaction', $transaction->connection, $connection);
         });
 
-        $event->listen(TransactionCommitted::class, function (TransactionCommitted $transaction) use ($db): void {
-            if (!$this->isEventConnectionEqual($db, $transaction->connection)) {
-                return;
-            }
-            if ($collector = $this->getRequestThisCollector()) {
-                $collector->collectTransactionEvent('Commit Transaction', $transaction->connection);
-            }
+        $event->listen(TransactionCommitted::class, function (TransactionCommitted $transaction) use ($connection): void {
+            $this->collectTransactionConnectionEvent('Commit Transaction', $transaction->connection, $connection);
         });
 
-        $event->listen(TransactionRolledBack::class, function (TransactionRolledBack $transaction) use ($db): void {
-            if (!$this->isEventConnectionEqual($db, $transaction->connection)) {
-                return;
-            }
-            if ($collector = $this->getRequestThisCollector()) {
-                $collector->collectTransactionEvent('Rollback Transaction', $transaction->connection);
-            }
+        $event->listen(TransactionRolledBack::class, function (TransactionRolledBack $transaction) use ($connection): void {
+            $this->collectTransactionConnectionEvent('Rollback Transaction', $transaction->connection, $connection);
         });
 
-        $event->listen('connection.*.beganTransaction', function ($event, $params): void {
-            if ($collector = $this->getRequestThisCollector()) {
-                $collector->collectTransactionEvent('Begin Transaction', $params[0]);
-            }
+        $event->listen('connection.*.beganTransaction', function ($event, $params) use ($connection): void {
+            $this->collectWildcardTransactionEvent('Begin Transaction', $params, $connection);
         });
 
-        $event->listen('connection.*.committed', function ($event, $params): void {
-            if ($collector = $this->getRequestThisCollector()) {
-                $collector->collectTransactionEvent('Commit Transaction', $params[0]);
-            }
+        $event->listen('connection.*.committed', function ($event, $params) use ($connection): void {
+            $this->collectWildcardTransactionEvent('Commit Transaction', $params, $connection);
         });
 
-        $event->listen('connection.*.rollingBack', function ($event, $params): void {
-            if ($collector = $this->getRequestThisCollector()) {
-                $collector->collectTransactionEvent('Rollback Transaction', $params[0]);
-            }
+        $event->listen('connection.*.rollingBack', function ($event, $params) use ($connection): void {
+            $this->collectWildcardTransactionEvent('Rollback Transaction', $params, $connection);
         });
+    }
+
+    private function collectQueryEvent(QueryExecuted $event, ?Connection $expectedConnection = null): void
+    {
+        if (!$this->shouldCollectConnection($event->connection, $expectedConnection)) {
+            return;
+        }
+
+        $threshold = $this->config['slow_threshold'];
+        if ($threshold && $event->time <= $threshold) {
+            return;
+        }
+
+        if ($collector = $this->getRequestThisCollector()) {
+            $collector->addQuery($event->sql, $event->bindings, $event->time, $event->connection);
+        }
+    }
+
+    private function collectTransactionConnectionEvent(
+        string $label,
+        Connection $eventConnection,
+        ?Connection $expectedConnection = null,
+    ): void {
+        if (!$this->shouldCollectConnection($eventConnection, $expectedConnection)) {
+            return;
+        }
+
+        if ($collector = $this->getRequestThisCollector()) {
+            $collector->collectTransactionEvent($label, $eventConnection);
+        }
+    }
+
+    /**
+     * @param array<mixed> $params
+     */
+    private function collectWildcardTransactionEvent(
+        string $label,
+        array $params,
+        ?Connection $expectedConnection = null,
+    ): void {
+        $eventConnection = $params[0] ?? null;
+        if (!$eventConnection instanceof Connection) {
+            return;
+        }
+
+        $this->collectTransactionConnectionEvent($label, $eventConnection, $expectedConnection);
     }
 
     /**
@@ -237,5 +260,14 @@ class LaravelQueryCollector extends QueryCollector
     protected function isEventConnectionEqual(Connection $connection, Connection $eventConnection): bool
     {
         return $connection->getName() === $eventConnection->getName();
+    }
+
+    private function shouldCollectConnection(Connection $eventConnection, ?Connection $expectedConnection = null): bool
+    {
+        if ($expectedConnection === null) {
+            return true;
+        }
+
+        return $this->isEventConnectionEqual($expectedConnection, $eventConnection);
     }
 }

--- a/tests/Unit/Debugbar/LaravelQueryTest.php
+++ b/tests/Unit/Debugbar/LaravelQueryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use WebmanTech\Debugbar\Bootstrap\LaravelQuery;
+use WebmanTech\Debugbar\DataCollector\LaravelQueryCollector;
+
+function debugbar_laravel_query_listen_for_query_events(LaravelQueryCollector $collector): void
+{
+    $method = new ReflectionMethod(LaravelQuery::class, 'listenForQueryEvents');
+    $method->setAccessible(true);
+    $method->invoke(null, $collector);
+}
+
+beforeEach(function () {
+    $property = new ReflectionProperty(LaravelQuery::class, 'registered');
+    $property->setAccessible(true);
+    $property->setValue(null, false);
+
+    $container = Container::getInstance();
+    $this->originalEvents = $container->bound('events') ? $container->make('events') : null;
+});
+
+afterEach(function () {
+    $container = Container::getInstance();
+    if ($this->originalEvents) {
+        $container->instance('events', $this->originalEvents);
+        return;
+    }
+
+    $container->forgetInstance('events');
+});
+
+it('registers query event listener only once', function () {
+    $container = Container::getInstance();
+    $dispatcher = $this->createMock(Dispatcher::class);
+    $collector = $this->getMockBuilder(LaravelQueryCollector::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['addEventDispatcherListener'])
+        ->getMock();
+
+    $container->instance('events', $dispatcher);
+
+    $collector->expects($this->once())
+        ->method('addEventDispatcherListener')
+        ->with($dispatcher);
+
+    debugbar_laravel_query_listen_for_query_events($collector);
+    debugbar_laravel_query_listen_for_query_events($collector);
+});
+
+it('ignores query event listener registration failures', function () {
+    $container = Container::getInstance();
+    $dispatcher = $this->createMock(Dispatcher::class);
+    $collector = $this->getMockBuilder(LaravelQueryCollector::class)
+        ->disableOriginalConstructor()
+        ->onlyMethods(['addEventDispatcherListener'])
+        ->getMock();
+
+    $container->instance('events', $dispatcher);
+
+    $collector->expects($this->once())
+        ->method('addEventDispatcherListener')
+        ->with($dispatcher)
+        ->willThrowException(new RuntimeException('listener unavailable'));
+
+    debugbar_laravel_query_listen_for_query_events($collector);
+});


### PR DESCRIPTION
## 变更说明

- 改为监听数据库事件 dispatcher 上实际发生的查询和事务事件
- 避免 debugbar 启动时遍历并初始化所有 database.connections
- 保留已使用连接的 SQL 采集能力
- 补充 LaravelQuery bootstrap 的回归测试

## 验证

- vendor/bin/pest tests/Unit/Debugbar/LaravelQueryTest.php

Closes #17