### PR TITLE
feat(swagger)!: 升级 swagger-php 至 ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "webman-tech/common-utils": "^5.0 || dev-main",
     "webman-tech/dto": "^5.0 || dev-main",
     "workerman/crontab": "^1.0",
-    "zircote/swagger-php": ">=5.2 <5.5"
+    "zircote/swagger-php": "^6.2"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.47",

--- a/packages/swagger/AGENTS.md
+++ b/packages/swagger/AGENTS.md
@@ -65,11 +65,11 @@ OpenAPI JSON (缓存，生产环境启动时生成)
 
 ## 注意事项
 
-1. **当前版本**：使用 swagger-php v5 (>=5.2 <5.5)
+1. **当前版本**：使用 swagger-php v6 (^6.2)
 2. **API 方法**：
-   - 使用 `getSchemaForSource()` 获取 Schema
-   - 使用 `$analysis->process([new Processor()])` 调用处理器
-3. **TypesTrait**：可以使用 `OpenApi\Processors\Concerns\TypesTrait` 进行类型映射
+   - 使用 `getAnnotationForSource()` 获取注解（替代 v5 的 `getSchemaForSource()`）
+   - v6 移除了 `Analysis::process()`，调用处理器需通过 Generator 的 Pipeline
+3. **类型映射**：v6 移除了 `TypesTrait`，改用 `Generator` 注入的 `getTypeResolver()`（实现 `GeneratorAwareInterface` + `GeneratorAwareTrait`）
 4. **性能优化**：
    - 生产环境使用缓存
    - 开发环境自动更新文档

--- a/packages/swagger/composer.json
+++ b/packages/swagger/composer.json
@@ -15,6 +15,6 @@
     "php": "^8.2",
     "webman-tech/dto": "^5.0 || dev-main",
     "webman-tech/common-utils": "^5.0 || dev-main",
-    "zircote/swagger-php": ">=5.2 <5.5"
+    "zircote/swagger-php": "^6.2"
   }
 }

--- a/packages/swagger/src/Helper/SwaggerHelper.php
+++ b/packages/swagger/src/Helper/SwaggerHelper.php
@@ -14,10 +14,13 @@ use OpenApi\Annotations\Schema as AnSchema;
 use OpenApi\Attributes\Components;
 use OpenApi\Attributes\MediaType;
 use OpenApi\Attributes\RequestBody;
+use OpenApi\Attributes\Response;
 use OpenApi\Attributes\Schema;
 use OpenApi\Generator;
+use ReflectionNamedType;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Webman\Http\UploadFile as WebmanUploadedFile;
+use WebmanTech\Swagger\DTO\SchemaConstants;
 use WebmanTech\Swagger\Enums\PropertyInEnum;
 use WebmanTech\Swagger\RouteAnnotation\DTO\XInPropertyDTO;
 
@@ -72,7 +75,32 @@ final class SwaggerHelper
             );
         }
 
-        return $className;
+        return $className ?: '';
+    }
+
+    /**
+     * 获取 property 的类型名称列表
+     *
+     * 优先从 x-property-types 获取，其次从 context reflector 获取
+     *
+     * @return string[]|null
+     */
+    public static function getPropertyContextTypes(AnProperty $property): ?array
+    {
+        $types = self::getAnnotationXValue($property, SchemaConstants::X_PROPERTY_TYPES);
+        if (is_array($types)) {
+            return array_values(array_filter($types, is_string(...)));
+        }
+
+        $contextReflector = $property->_context->reflector;
+        if ($contextReflector instanceof \ReflectionProperty) {
+            $contextReflectorType = $contextReflector->getType();
+            if ($contextReflectorType instanceof ReflectionNamedType) {
+                return [$contextReflectorType->getName()];
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -148,6 +176,19 @@ final class SwaggerHelper
         ], fn($item) => $item !== null));
         $schema->_context = $property->_context;
         return $schema;
+    }
+
+    /**
+     * 通过 property/schema 构造二进制响应体 Schema
+     */
+    public static function renewBinarySchema(AnProperty|AnSchema $source): AnSchema
+    {
+        return new Schema(
+            description: SwaggerHelper::getValue($source->description, Generator::UNDEFINED),
+            type: 'string',
+            format: 'binary',
+            nullable: SwaggerHelper::getValue($source->nullable),
+        );
     }
 
     /**
@@ -231,6 +272,39 @@ final class SwaggerHelper
     }
 
     /**
+     * 获取 operation 上指定状态码的 response
+     */
+    public static function getOperationResponse(AnOperation $operation, int $statusCode): ?AnResponse
+    {
+        foreach (SwaggerHelper::getValue($operation->responses, []) as $response) {
+            if (intval(SwaggerHelper::getValue($response->response)) === $statusCode) {
+                return $response;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 获取或创建 operation 上指定状态码的 response
+     */
+    public static function getOrCreateOperationResponse(AnOperation $operation, int $statusCode = 200, string $description = 'OK'): AnResponse
+    {
+        if (Generator::isDefault($operation->responses)) {
+            $operation->responses = [];
+        }
+        $response = self::getOperationResponse($operation, $statusCode);
+        if ($response) {
+            return $response;
+        }
+        $response = new Response(
+            response: $statusCode,
+            description: $description,
+        );
+        $operation->responses = [...$operation->responses, $response];
+        return $response;
+    }
+
+    /**
      * 将 schema 添加到 mediaType
      * @param string $combineType 组合类型，支持 'allOf' 或 'oneOf'
      */
@@ -244,7 +318,7 @@ final class SwaggerHelper
         // 附加用的 schema，如果可以用 ref 的话，使用 ref
         $appendSchema = $schema;
         if (!Generator::isDefault($schema->schema)) {
-            $refSchema = $analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $refSchema = $analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
             if ($refSchema) {
                 $appendSchema = new Schema(ref: Components::ref($schema));
             } else {
@@ -342,7 +416,7 @@ final class SwaggerHelper
     public static function hasXInBodyProperty(Analysis $analysis, AnSchema $schema): bool
     {
         if (!Generator::isDefault($schema->ref)) {
-            $schema = $analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $schema = $analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
             if (!$schema) {
                 return false;
             }

--- a/packages/swagger/src/Overwrite/Analysers/AttributeAnnotationFactory.php
+++ b/packages/swagger/src/Overwrite/Analysers/AttributeAnnotationFactory.php
@@ -7,7 +7,6 @@ use OpenApi\Annotations\Schema as AnSchema;
 use OpenApi\Attributes\Property;
 use OpenApi\Attributes\Schema;
 use OpenApi\Context;
-use OpenApi\Processors\Concerns\TypesTrait;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionEnum;
@@ -15,8 +14,6 @@ use ReflectionProperty;
 
 class AttributeAnnotationFactory extends \OpenApi\Analysers\AttributeAnnotationFactory
 {
-    use TypesTrait;
-
     private Context $buildContext;
 
     public function __construct(
@@ -65,7 +62,8 @@ class AttributeAnnotationFactory extends \OpenApi\Analysers\AttributeAnnotationF
             // 设置枚举的类型，否则默认会取 枚举 的键名
             /** @phpstan-ignore-next-line */
             $reflectorEnum = new ReflectionEnum($reflector->getName());
-            $this->mapNativeType($schema, $reflectorEnum->getBackingType()?->getName() ?? 'string');
+            $backingType = $reflectorEnum->getBackingType()?->getName() ?? 'string';
+            $this->generator?->getTypeResolver()->mapNativeType($schema, $backingType);
         }
 
         return $schema;

--- a/packages/swagger/src/Overwrite/Analysis.php
+++ b/packages/swagger/src/Overwrite/Analysis.php
@@ -2,7 +2,7 @@
 
 namespace WebmanTech\Swagger\Overwrite;
 
-use OpenApi\Annotations\Schema as AnSchema;
+use OpenApi\Annotations as OA;
 
 /**
  * @internal
@@ -19,10 +19,10 @@ final class Analysis extends \OpenApi\Analysis
     /**
      * @inheritDoc
      */
-    public function getSchemaForSource(string $fqdn): ?AnSchema
+    public function getAnnotationForSource(string $fqdn, string $sourceClass = OA\Schema::class): ?OA\AbstractAnnotation
     {
-        $schema = parent::getSchemaForSource($fqdn);
-        if ($this->schemaNameFormatter && $schema && $schema->isRoot(AnSchema::class)) {
+        $schema = parent::getAnnotationForSource($fqdn, $sourceClass);
+        if ($this->schemaNameFormatter && $schema && $schema->isRoot(OA\Schema::class)) {
             call_user_func($this->schemaNameFormatter, $schema);
         }
         return $schema;

--- a/packages/swagger/src/RouteAnnotation/DTO/XInPropertyDTO.php
+++ b/packages/swagger/src/RouteAnnotation/DTO/XInPropertyDTO.php
@@ -89,13 +89,7 @@ final class XInPropertyDTO
                 // body 参数仅能设置一次
                 return;
             }
-            $mediaSchema = new Schema(
-                description: SwaggerHelper::getValue($this->property->description),
-                type: 'string',
-                format: 'binary',
-                nullable: SwaggerHelper::getValue($this->property->nullable),
-            );
-            $mediaType->schema = $mediaSchema;
+            $mediaType->schema = SwaggerHelper::renewBinarySchema($this->property);
         } elseif ($this->in === PropertyInEnum::Json) {
             $mediaType = SwaggerHelper::getOperationRequestBodyMediaType($operation, 'application/json');
             $schema = new Schema(
@@ -128,13 +122,7 @@ final class XInPropertyDTO
                 // body 参数仅能设置一次
                 return;
             }
-            $mediaSchema = new Schema(
-                description: SwaggerHelper::getValue($this->property->description),
-                type: 'string',
-                format: 'binary',
-                nullable: SwaggerHelper::getValue($this->property->nullable),
-            );
-            $mediaType->schema = $mediaSchema;
+            $mediaType->schema = SwaggerHelper::renewBinarySchema($this->property);
         } elseif ($this->in === PropertyInEnum::Json) {
             $mediaType = SwaggerHelper::getResponseMediaType($response, 'application/json');
             $schema = new Schema(

--- a/packages/swagger/src/RouteAnnotation/Processors/AppendResponseProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/AppendResponseProcessor.php
@@ -4,8 +4,8 @@ namespace WebmanTech\Swagger\RouteAnnotation\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Operation as AnOperation;
-use OpenApi\Attributes\Response;
 use OpenApi\Generator;
+use WebmanTech\Swagger\Helper\SwaggerHelper;
 
 /**
  * 给 Operation 添加必须的 response
@@ -18,14 +18,8 @@ final class AppendResponseProcessor
         $operations = $analysis->getAnnotationsOfType(AnOperation::class);
 
         foreach ($operations as $operation) {
-            if (Generator::isDefault($operation->responses)) {
-                $operation->responses = [];
-            }
-            if (count($operation->responses) === 0) {
-                $operation->responses[200] = new Response(
-                    response: 200,
-                    description: 'OK',
-                );
+            if (Generator::isDefault($operation->responses) || count($operation->responses) === 0) {
+                SwaggerHelper::getOrCreateOperationResponse($operation);
             }
         }
     }

--- a/packages/swagger/src/RouteAnnotation/Processors/ExpandDTOAttributionsProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/ExpandDTOAttributionsProcessor.php
@@ -93,7 +93,7 @@ final class ExpandDTOAttributionsProcessor
                     // 修正 example 类型
                     $this->fixExample($property);
                 }
-                SwaggerHelper::setValue($schema->required, $schemaRequired);
+                SwaggerHelper::setValue($schema->required, array_values($schemaRequired));
             }
 
             if ($this->appendValidationRulesInDescription && is_a($className, BaseRequestDTO::class, true)) {
@@ -110,19 +110,14 @@ final class ExpandDTOAttributionsProcessor
             return;
         }
         // 自定义类型
-        $types = SwaggerHelper::getAnnotationXValue($property, SchemaConstants::X_PROPERTY_TYPES, array_filter([
-            // 默认先取 swagger-php 已经取到的类型
-            $property->_context->type,
-        ]));
+        $types = SwaggerHelper::getPropertyContextTypes($property);
         if ($types) {
             $this->fixUploadedFileType($property, $types);
             return;
         }
-        // 没有类型定义的情况
-        // 1. 本身代码就没定义类型
-        // 2. swagger-php 不能解析联合类型（此处做支持）
+        // swagger-php 不能解析联合类型（此处做支持）
         $types = [];
-        if (!$property->_context->type && $property->_context->property) {
+        if ($property->_context->property) {
             /** @var class-string $className */
             $className = SwaggerHelper::getAnnotationClassName($property);
             $reflectPropertyType = (new ReflectionProperty($className, $property->_context->property))
@@ -231,16 +226,18 @@ final class ExpandDTOAttributionsProcessor
                     }
                     $this->fillPropertyByValidationRules($newProperty, $validationRules->arrayItem, $newRequired);
                     $schemaItems = SwaggerHelper::renewSchemaWithProperty($newProperty, AnItems::class);
-                    SwaggerHelper::setValue($schemaItems->required, $newRequired);
+                    SwaggerHelper::setValue($schemaItems->required, array_values($newRequired));
                 } elseif (is_string($validationRules->arrayItem) && class_exists($validationRules->arrayItem)) {
-                    if ($schemaNew = $this->analysis->getSchemaForSource($validationRules->arrayItem)) {
+                    if ($schemaNew = $this->analysis->getAnnotationForSource($validationRules->arrayItem)) {
                         $schemaItems = new Items(ref: Components::ref($schemaNew));
                     }
                 }
                 $property->items = $schemaItems ?? new Items();
             }
         }
-        if ($property->type === 'object' && $validationRules->arrayItem && Generator::isDefault($property->additionalProperties)) {
+        if ($property->type === 'object' && $validationRules->arrayItem) {
+            // v6.1.2+ 上游可能已创建 additionalProperties（如从 @var 解析 nullable oneOf），
+            // 但 DTO 校验规则是更权威的来源，因此始终覆盖
             // 定义为对象
             if ($validationRules->arrayItem instanceof ValidationRules) {
                 // 检查是否是嵌套数组（arrayItem 也有 arrayItem，表示 value 是数组类型）
@@ -253,7 +250,7 @@ final class ExpandDTOAttributionsProcessor
                     if ($validationRules->arrayItem->arrayItem instanceof ValidationRules) {
                         $this->fillPropertyByValidationRules($newProperty, $validationRules->arrayItem->arrayItem, $newRequired);
                     } elseif (is_string($validationRules->arrayItem->arrayItem) && class_exists($validationRules->arrayItem->arrayItem)) {
-                        if ($schemaNew = $this->analysis->getSchemaForSource($validationRules->arrayItem->arrayItem)) {
+                        if ($schemaNew = $this->analysis->getAnnotationForSource($validationRules->arrayItem->arrayItem)) {
                             $newProperty->items = new Items(ref: Components::ref($schemaNew));
                         }
                     }
@@ -286,7 +283,7 @@ final class ExpandDTOAttributionsProcessor
                     }
                 }
             } elseif (is_string($validationRules->arrayItem) && class_exists($validationRules->arrayItem)) {
-                if ($schemaNew = $this->analysis->getSchemaForSource($validationRules->arrayItem)) {
+                if ($schemaNew = $this->analysis->getAnnotationForSource($validationRules->arrayItem)) {
                     $property->additionalProperties = $this->makeAdditionalProperties(
                         ref: Components::ref($schemaNew),
                         nullable: $validationRules->objectValueNullable ?? $validationRules->nullable,

--- a/packages/swagger/src/RouteAnnotation/Processors/ExpandEloquentModelProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/ExpandEloquentModelProcessor.php
@@ -41,7 +41,7 @@ final class ExpandEloquentModelProcessor implements GeneratorAwareInterface
                 continue;
             }
             $className = $schema->_context->fullyQualifiedName($schema->_context->class);
-            if (!is_a($className, Model::class, true)) {
+            if ($className === null || !is_a($className, Model::class, true)) {
                 continue;
             }
             $schema->properties = array_values(array_merge(

--- a/packages/swagger/src/RouteAnnotation/Processors/ExpandEloquentModelProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/ExpandEloquentModelProcessor.php
@@ -6,15 +6,17 @@ use Illuminate\Database\Eloquent\Model;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Schema as AnSchema;
 use OpenApi\Attributes\Property;
-use OpenApi\Processors\Concerns\TypesTrait;
+use OpenApi\Generator;
+use OpenApi\GeneratorAwareInterface;
+use OpenApi\GeneratorAwareTrait;
 use WebmanTech\Swagger\Helper\SwaggerHelper;
 
 /**
  * 自动扫描 Eloquent Model 的属性，生成 Schema 的 属性
  */
-final class ExpandEloquentModelProcessor
+final class ExpandEloquentModelProcessor implements GeneratorAwareInterface
 {
-    use TypesTrait;
+    use GeneratorAwareTrait;
 
     public function __construct(
         private bool $enabled = true,
@@ -42,10 +44,10 @@ final class ExpandEloquentModelProcessor
             if (!is_a($className, Model::class, true)) {
                 continue;
             }
-            $schema->properties = array_merge(
+            $schema->properties = array_values(array_merge(
                 SwaggerHelper::getValue($schema->properties, []),
                 $this->getModelProperties($className),
-            );
+            ));
         }
     }
 
@@ -100,7 +102,7 @@ final class ExpandEloquentModelProcessor
                     property: $name,
                     description: $desc,
                 );
-                $this->mapNativeType($property, $type);
+                ($this->generator ?? new Generator())->getTypeResolver()->mapNativeType($property, $type);
                 if ($nullable) {
                     $property->nullable = true;
                 }

--- a/packages/swagger/src/RouteAnnotation/Processors/ExpandEnumDescriptionProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/ExpandEnumDescriptionProcessor.php
@@ -44,7 +44,7 @@ final readonly class ExpandEnumDescriptionProcessor
             if (!Generator::isDefault($schema->enum) && $schema->_context->is('enum')) {
                 $className = $schema->_context->fullyQualifiedName($schema->_context->enum);
                 $caseDesc = [];
-                if (is_a($className, \BackedEnum::class, true)) {
+                if ($className !== null && is_a($className, \BackedEnum::class, true)) {
                     foreach ($schema->enum as $item) {
                         $case = $className::tryFrom($item);
                         if (!$case) {

--- a/packages/swagger/src/RouteAnnotation/Processors/ResponseLayoutProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/ResponseLayoutProcessor.php
@@ -51,8 +51,7 @@ final class ResponseLayoutProcessor
             $layoutSchema = $layoutClass === $undefinedOperationLayoutKey ? $globalLayoutSchema : $this->getLayoutSchema($layoutClass);
             $layoutDataCode = SwaggerHelper::getAnnotationXValue($operation, SchemaConstants::X_RESPONSE_LAYOUT_DATA_CODE, $this->layoutDataCode, remove: true);
 
-            /** @var AnResponse|null $response */
-            $response = SwaggerHelper::getValue($operation->responses, [])[200] ?? null;
+            $response = SwaggerHelper::getOperationResponse($operation, 200);
             if (!$response) {
                 continue;
             }
@@ -99,7 +98,7 @@ final class ResponseLayoutProcessor
 
     private function getLayoutSchema(string $layoutClass): AnSchema
     {
-        $schema = $this->analysis->getSchemaForSource($layoutClass);
+        $schema = $this->analysis->getAnnotationForSource($layoutClass);
         if (!$schema) {
             throw new \InvalidArgumentException("layoutClass({$layoutClass}) must defined as schema（Not in scanned path?）");
         }

--- a/packages/swagger/src/RouteAnnotation/Processors/XDiscriminatorProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/XDiscriminatorProcessor.php
@@ -73,7 +73,7 @@ final class XDiscriminatorProcessor
                 continue;
             }
 
-            $childSchema = $this->analysis->getSchemaForSource($dtoClass);
+            $childSchema = $this->analysis->getAnnotationForSource($dtoClass);
             if (!$childSchema) {
                 continue;
             }

--- a/packages/swagger/src/RouteAnnotation/Processors/XSchemaRequestProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/XSchemaRequestProcessor.php
@@ -84,7 +84,7 @@ final class XSchemaRequestProcessor
                     // $class@method 的形式
                     [$class] = $classMethod = explode('@', $schema);
                 }
-                $schema = $this->analysis->getSchemaForSource($class);
+                $schema = $this->analysis->getAnnotationForSource($class);
                 if (!$schema instanceof AnSchema) {
                     throw new \InvalidArgumentException(sprintf('Class `%s` not exists, in %s', $class, $operation->_context));
                 }
@@ -109,7 +109,7 @@ final class XSchemaRequestProcessor
         }
         // schema 是 ref 的情况下，取到真实的 schema
         if (!Generator::isDefault($schema->ref)) {
-            $schema = $this->analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $schema = $this->analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
         }
         if (!$schema) {
             return;
@@ -147,7 +147,7 @@ final class XSchemaRequestProcessor
         }
         if (!Generator::isDefault($schema->ref)) {
             // 使用 ref 的情况，取真实 schema
-            $schema = $this->analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $schema = $this->analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
             if (!$schema) {
                 return 0;
             }
@@ -166,11 +166,8 @@ final class XSchemaRequestProcessor
         }
 
         foreach (SwaggerHelper::getValue($schema->properties, []) as $property) {
-            /** @var array $types */
-            $types = SwaggerHelper::getAnnotationXValue($property, SchemaConstants::X_PROPERTY_TYPES, array_filter([
-                $property->_context->type,
-            ]));
-            if (!$types) {
+            $types = SwaggerHelper::getPropertyContextTypes($property);
+            if (!is_array($types)) {
                 continue;
             }
             // 有其中一个属性是
@@ -193,7 +190,7 @@ final class XSchemaRequestProcessor
             SwaggerHelper::getValue($operation->parameters, []),
             $this->transferSchemaProperties2parameters($schema, $operation->_context, $propertyIn),
         );
-        $operation->parameters = $parameters;
+        $operation->parameters = array_values($parameters);
     }
 
     private function transferSchemaProperties2parameters(AnSchema $schema, Context $context, PropertyInEnum $propertyIn): array
@@ -210,7 +207,7 @@ final class XSchemaRequestProcessor
         }
         // schema 是 ref 的情况下，取到真实的 schema
         if (!Generator::isDefault($schema->ref)) {
-            $schema = $this->analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $schema = $this->analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
             if ($schema) {
                 $parameters = $this->transferSchemaProperties2parameters($schema, $context, $propertyIn);
             }

--- a/packages/swagger/src/RouteAnnotation/Processors/XSchemaResponseProcessor.php
+++ b/packages/swagger/src/RouteAnnotation/Processors/XSchemaResponseProcessor.php
@@ -7,7 +7,6 @@ use OpenApi\Annotations\Operation as AnOperation;
 use OpenApi\Annotations\Property as AnProperty;
 use OpenApi\Annotations\Response as AnResponse;
 use OpenApi\Annotations\Schema as AnSchema;
-use OpenApi\Attributes\Response;
 use OpenApi\Attributes\Schema;
 use OpenApi\Context;
 use OpenApi\Generator;
@@ -36,7 +35,7 @@ final class XSchemaResponseProcessor
             }
             $propertyDefaultIn = PropertyInEnum::Json;
             foreach ($schemaList as $statusCode => $schemas) {
-                $response = $this->getResponse($operation, $statusCode);
+                $response = SwaggerHelper::getOrCreateOperationResponse($operation, $statusCode);
                 foreach ($schemas as $schema) {
                     // 根据 property in 所在的地方，将数据转移到不同上面
                     $propertyIn = PropertyInEnum::tryFromSchemaX($schema, $propertyDefaultIn);
@@ -95,7 +94,7 @@ final class XSchemaResponseProcessor
                 // 字符串的形式
                 if (class_exists($schema) || trait_exists($schema) || interface_exists($schema)) {
                     $class = $schema;
-                    $schema = $this->analysis->getSchemaForSource($class);
+                    $schema = $this->analysis->getAnnotationForSource($class);
                     if (!$schema instanceof AnSchema) {
                         throw new \InvalidArgumentException(sprintf('Class `%s` is not schema(not scan?), in %s', $class, $operation->_context));
                     }
@@ -112,20 +111,6 @@ final class XSchemaResponseProcessor
         }, $schemaList), $schemaList);
     }
 
-    private function getResponse(AnOperation $operation, int $statusCode): AnResponse
-    {
-        if (Generator::isDefault($operation->responses)) {
-            $operation->responses = [];
-        }
-        if (!isset($operation->responses[$statusCode])) {
-            $operation->responses[$statusCode] = new Response(
-                response: $statusCode,
-                description: 'OK',
-            );
-        }
-        return $operation->responses[$statusCode];
-    }
-
     private function addXInProperties(AnResponse $response, AnSchema $schema): void
     {
         // allOf 的逐个处理掉
@@ -136,7 +121,7 @@ final class XSchemaResponseProcessor
         }
         // schema 是 ref 的情况下，取到真实的 schema
         if (!Generator::isDefault($schema->ref)) {
-            $schema = $this->analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $schema = $this->analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
         }
         if (!$schema) {
             return;
@@ -176,7 +161,7 @@ final class XSchemaResponseProcessor
     {
         // 如果是 ref，检查真实的 schema
         if (!Generator::isDefault($schema->ref)) {
-            $realSchema = $this->analysis->getSchemaForSource(SwaggerHelper::getAnnotationClassName($schema));
+            $realSchema = $this->analysis->getAnnotationForSource(SwaggerHelper::getAnnotationClassName($schema));
             if ($realSchema) {
                 return $this->isEmptySchema($realSchema);
             }
@@ -208,7 +193,7 @@ final class XSchemaResponseProcessor
             SwaggerHelper::getValue($response->headers, []),
             $this->transferSchemaProperties2headers($schema, $response->_context),
         );
-        $response->headers = $headers;
+        $response->headers = array_values($headers);
     }
 
     private function transferSchemaProperties2headers(AnSchema $schema, Context $context): array
@@ -235,14 +220,7 @@ final class XSchemaResponseProcessor
 
     private function add2responseBodyUseSchema(AnResponse $response, AnSchema $schema): void
     {
-        $mediaSchema = new Schema(
-            description: SwaggerHelper::getValue($schema->description),
-            type: 'string',
-            format: 'binary',
-            nullable: SwaggerHelper::getValue($schema->nullable),
-        );
-
         $mediaType = SwaggerHelper::getResponseMediaType($response, 'application/octet-stream');
-        $mediaType->schema = $mediaSchema;
+        $mediaType->schema = SwaggerHelper::renewBinarySchema($schema);
     }
 }

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc.snap
@@ -44,7 +44,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: { schema: { required: [username, password, name], properties: { username: { description: 用户名, type: string, maxLength: 64, example: admin }, password: { description: 密码, type: string, maxLength: 64, example: '123456' }, name: { description: 名称, type: string, example: 测试用户 } }, type: object } }
+          application/json: { schema: { required: [username, password, name], properties: { username: { description: 用户名, type: string, example: admin, maxLength: 64 }, password: { description: 密码, type: string, example: '123456', maxLength: 64 }, name: { description: 名称, type: string, example: 测试用户 } }, type: object } }
       responses:
         200:
           description: 新建后的明细
@@ -78,7 +78,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json: { schema: { properties: { username: { description: 用户名, type: string, maxLength: 64, example: admin }, password: { description: 密码, type: string, maxLength: 64, example: '123456' }, name: { description: 名称, type: string, example: 测试用户 }, status: { description: 状态, type: integer, example: 0 } }, type: object } }
+          application/json: { schema: { properties: { username: { description: 用户名, type: string, example: admin, maxLength: 64 }, password: { description: 密码, type: string, example: '123456', maxLength: 64 }, name: { description: 名称, type: string, example: 测试用户 }, status: { description: 状态, type: integer, example: 0 } }, type: object } }
       responses:
         200:
           description: 更新后的明细

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc.snap
@@ -1,149 +1,292 @@
-openapi: 3.1.0
-info:
-  title: 'App OpenAPI'
-  version: '0.1'
-paths:
-  /crud:
-    get:
-      tags:
-        - crud
-      summary: 列表
-      operationId: cc9c964cb86b42e80a1c63de2d373985
-      parameters:
-        -
-          name: page
-          in: query
-          description: 页数
-          schema: { type: integer }
-        -
-          name: page_size
-          in: query
-          description: 每页数量
-          schema: { type: integer }
-        -
-          name: username
-          in: query
-          description: 用户名
-          schema: { type: string }
-        -
-          name: status
-          in: query
-          description: 状态
-          schema: { type: integer }
-      responses:
-        200:
-          description: 列表数据
-      security:
-        -
-          api_key: {}
-    post:
-      tags:
-        - crud
-      summary: 新建
-      operationId: cfb89cdcd5dfc4a7cb700b3a826a3fa4
-      requestBody:
-        required: true
-        content:
-          application/json: { schema: { required: [username, password, name], properties: { username: { description: 用户名, type: string, example: admin, maxLength: 64 }, password: { description: 密码, type: string, example: '123456', maxLength: 64 }, name: { description: 名称, type: string, example: 测试用户 } }, type: object } }
-      responses:
-        200:
-          description: 新建后的明细
-      security:
-        -
-          api_key: {}
-  '/crud/{id}':
-    get:
-      tags:
-        - crud
-      summary: 详情
-      operationId: 0477ab6896cd25e9a55d25ff9c543ce6
-      parameters:
-        -
-          name: id
-          in: path
-          description: ID
-          required: true
-          schema: { type: integer }
-      responses:
-        200:
-          description: 明细
-      security:
-        -
-          api_key: {}
-    put:
-      tags:
-        - crud
-      summary: 更新
-      operationId: 16cf3e22371f422bf78f0f9c4b6aba84
-      requestBody:
-        required: true
-        content:
-          application/json: { schema: { properties: { username: { description: 用户名, type: string, example: admin, maxLength: 64 }, password: { description: 密码, type: string, example: '123456', maxLength: 64 }, name: { description: 名称, type: string, example: 测试用户 }, status: { description: 状态, type: integer, example: 0 } }, type: object } }
-      responses:
-        200:
-          description: 更新后的明细
-      security:
-        -
-          api_key: {}
-    delete:
-      tags:
-        - crud
-      summary: 删除
-      operationId: 0c4b7efabbd614426813b6741fab768c
-      parameters:
-        -
-          name: id
-          in: path
-          description: ID
-          required: true
-          schema: { type: integer }
-      responses:
-        200:
-          description: 无返回数据
-      security:
-        -
-          api_key: {}
-  '/crud/{id}/recovery':
-    put:
-      tags:
-        - crud
-      summary: 恢复
-      operationId: 73484e636b915ccd2442ad40b9376db3
-      parameters:
-        -
-          name: id
-          in: path
-          description: ID
-          required: true
-          schema: { type: integer }
-      responses:
-        200:
-          description: 明细
-      security:
-        -
-          api_key: {}
-  /same-path:
-    get:
-      operationId: a16af954711ddf37a3be80134cf418aa
-      responses:
-        200:
-          description: OK
-    put:
-      operationId: 3dfc4a91d3b7bb5bef9dc0784310e7e1
-      responses:
-        200:
-          description: OK
-    post:
-      operationId: 443d2de84262eb071730681473d1cca6
-      responses:
-        200:
-          description: OK
-    delete:
-      operationId: 0cac586e86cf5c2796219368f0d0ca61
-      responses:
-        200:
-          description: OK
-tags:
-  -
-    name: crud
-    description: 'crud 例子'
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "App OpenAPI",
+        "version": "0.1"
+    },
+    "paths": {
+        "/crud": {
+            "get": {
+                "tags": [
+                    "crud"
+                ],
+                "summary": "列表",
+                "operationId": "cc9c964cb86b42e80a1c63de2d373985",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "页数",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "in": "query",
+                        "description": "每页数量",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "用户名",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "状态",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "列表数据"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "crud"
+                ],
+                "summary": "新建",
+                "operationId": "cfb89cdcd5dfc4a7cb700b3a826a3fa4",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "username",
+                                    "password",
+                                    "name"
+                                ],
+                                "properties": {
+                                    "username": {
+                                        "description": "用户名",
+                                        "type": "string",
+                                        "example": "admin",
+                                        "maxLength": 64
+                                    },
+                                    "password": {
+                                        "description": "密码",
+                                        "type": "string",
+                                        "example": "123456",
+                                        "maxLength": 64
+                                    },
+                                    "name": {
+                                        "description": "名称",
+                                        "type": "string",
+                                        "example": "测试用户"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "新建后的明细"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/crud/{id}": {
+            "get": {
+                "tags": [
+                    "crud"
+                ],
+                "summary": "详情",
+                "operationId": "0477ab6896cd25e9a55d25ff9c543ce6",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "明细"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "crud"
+                ],
+                "summary": "更新",
+                "operationId": "16cf3e22371f422bf78f0f9c4b6aba84",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "username": {
+                                        "description": "用户名",
+                                        "type": "string",
+                                        "example": "admin",
+                                        "maxLength": 64
+                                    },
+                                    "password": {
+                                        "description": "密码",
+                                        "type": "string",
+                                        "example": "123456",
+                                        "maxLength": 64
+                                    },
+                                    "name": {
+                                        "description": "名称",
+                                        "type": "string",
+                                        "example": "测试用户"
+                                    },
+                                    "status": {
+                                        "description": "状态",
+                                        "type": "integer",
+                                        "example": 0
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "更新后的明细"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "crud"
+                ],
+                "summary": "删除",
+                "operationId": "0c4b7efabbd614426813b6741fab768c",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "无返回数据"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/crud/{id}/recovery": {
+            "put": {
+                "tags": [
+                    "crud"
+                ],
+                "summary": "恢复",
+                "operationId": "73484e636b915ccd2442ad40b9376db3",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "明细"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    }
+                ]
+            }
+        },
+        "/same-path": {
+            "get": {
+                "operationId": "a16af954711ddf37a3be80134cf418aa",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "3dfc4a91d3b7bb5bef9dc0784310e7e1",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "443d2de84262eb071730681473d1cca6",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "0cac586e86cf5c2796219368f0d0ca61",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "crud",
+            "description": "crud 例子"
+        }
+    ]
+}

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc.snap
@@ -35,7 +35,7 @@ paths:
           description: 列表数据
       security:
         -
-          api_key: {  }
+          api_key: {}
     post:
       tags:
         - crud
@@ -50,7 +50,7 @@ paths:
           description: 新建后的明细
       security:
         -
-          api_key: {  }
+          api_key: {}
   '/crud/{id}':
     get:
       tags:
@@ -69,7 +69,7 @@ paths:
           description: 明细
       security:
         -
-          api_key: {  }
+          api_key: {}
     put:
       tags:
         - crud
@@ -84,7 +84,7 @@ paths:
           description: 更新后的明细
       security:
         -
-          api_key: {  }
+          api_key: {}
     delete:
       tags:
         - crud
@@ -102,7 +102,7 @@ paths:
           description: 无返回数据
       security:
         -
-          api_key: {  }
+          api_key: {}
   '/crud/{id}/recovery':
     put:
       tags:
@@ -121,7 +121,7 @@ paths:
           description: 明细
       security:
         -
-          api_key: {  }
+          api_key: {}
   /same-path:
     get:
       operationId: a16af954711ddf37a3be80134cf418aa

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_discriminator_example.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_discriminator_example.snap
@@ -156,10 +156,10 @@
                     "type": {
                         "description": "订单类型",
                         "type": "string",
+                        "example": "normal",
                         "enum": [
                             "express"
-                        ],
-                        "example": "normal"
+                        ]
                     },
                     "userId": {
                         "description": "用户ID",
@@ -189,10 +189,10 @@
                     "type": {
                         "description": "订单类型",
                         "type": "string",
+                        "example": "normal",
                         "enum": [
                             "normal"
-                        ],
-                        "example": "normal"
+                        ]
                     },
                     "userId": {
                         "description": "用户ID",
@@ -261,10 +261,10 @@
                     "type": {
                         "description": "订单类型",
                         "type": "string",
+                        "example": "normal",
                         "enum": [
                             "express"
-                        ],
-                        "example": "normal"
+                        ]
                     },
                     "orderId": {
                         "description": "订单ID",
@@ -287,10 +287,10 @@
                     "type": {
                         "description": "订单类型",
                         "type": "string",
+                        "example": "normal",
                         "enum": [
                             "normal"
-                        ],
-                        "example": "normal"
+                        ]
                     },
                     "orderId": {
                         "description": "订单ID",

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_dto_example.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_dto_example.snap
@@ -111,9 +111,9 @@
                     "prices": {
                         "description": "浮点数数组",
                         "type": "array",
-                        "format": "float",
                         "items": {
-                            "type": "number"
+                            "type": "number",
+                            "format": "float"
                         }
                     },
                     "metadata": {
@@ -159,7 +159,8 @@
                     },
                     "extra": {
                         "description": "混合类型的关联数组",
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": {}
                     },
                     "nickname": {
                         "description": "可空的简单类型",
@@ -255,8 +256,8 @@
                     "enabled": {
                         "description": "是否启用",
                         "type": "boolean",
-                        "default": true,
-                        "example": true
+                        "example": true,
+                        "default": true
                     }
                 },
                 "type": "object"

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_generate_json.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_generate_json.snap
@@ -77,14 +77,14 @@
                                     "username": {
                                         "description": "用户名",
                                         "type": "string",
-                                        "maxLength": 64,
-                                        "example": "admin"
+                                        "example": "admin",
+                                        "maxLength": 64
                                     },
                                     "password": {
                                         "description": "密码",
                                         "type": "string",
-                                        "maxLength": 64,
-                                        "example": "123456"
+                                        "example": "123456",
+                                        "maxLength": 64
                                     },
                                     "name": {
                                         "description": "名称",
@@ -153,14 +153,14 @@
                                     "username": {
                                         "description": "用户名",
                                         "type": "string",
-                                        "maxLength": 64,
-                                        "example": "admin"
+                                        "example": "admin",
+                                        "maxLength": 64
                                     },
                                     "password": {
                                         "description": "密码",
                                         "type": "string",
-                                        "maxLength": 64,
-                                        "example": "123456"
+                                        "example": "123456",
+                                        "maxLength": 64
                                     },
                                     "name": {
                                         "description": "名称",

--- a/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_keeps_schema_referenced_by_sub_path_ref_when_clean_unused_components_enabled.snap
+++ b/tests/.pest/snapshots/Unit/Swagger/Controller/OpenapiControllerTest/openapiDoc_keeps_schema_referenced_by_sub_path_ref_when_clean_unused_components_enabled.snap
@@ -52,6 +52,18 @@
         }
     },
     "components": {
+        "schemas": {
+            "ControllerForXSchemaRequestBodyPropertySchema": {
+                "type": "object",
+                "x-in-property-parameter": {
+                    "ControllerForXSchemaRequestBodyPropertySchema_X-File-Key": "#/components/parameters/ControllerForXSchemaRequestBodyPropertySchema_X-File-Key",
+                    "ControllerForXSchemaRequestBodyPropertySchema_encode": "#/components/parameters/ControllerForXSchemaRequestBodyPropertySchema_encode"
+                }
+            },
+            "ControllerForXSchemaRequestBodyPropertySchemaResult": {
+                "type": "object"
+            }
+        },
         "parameters": {
             "ControllerForXSchemaRequestBodyPropertySchema_X-File-Key": {
                 "name": "X-File-Key",

--- a/tests/Fixtures/Swagger/Overwrite/ClassWithMissingType.php
+++ b/tests/Fixtures/Swagger/Overwrite/ClassWithMissingType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Fixtures\Swagger\Overwrite;
+
+// 属性类型引用了一个不存在的类，用于触发 ReflectionAnalyser 的 Class not found 错误处理
+// PHP 不会在加载时解析类型提示，所以此文件可以正常加载
+class ClassWithMissingType extends \WebmanTech\DTO\BaseDTO
+{
+    public \NonExistent\SomeClass $missing;
+}

--- a/tests/Fixtures/Swagger/Overwrite/ClassWithStaticProp.php
+++ b/tests/Fixtures/Swagger/Overwrite/ClassWithStaticProp.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Fixtures\Swagger\Overwrite;
+
+use WebmanTech\DTO\BaseDTO;
+
+// 包含 static 属性的 DTO 类，用于测试 static 属性不被自动生成 Property
+class ClassWithStaticProp extends BaseDTO
+{
+    public string $name;
+    public static string $staticName = 'default';
+}

--- a/tests/Fixtures/Swagger/Overwrite/ExplicitNamedSchema.php
+++ b/tests/Fixtures/Swagger/Overwrite/ExplicitNamedSchema.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Fixtures\Swagger\Overwrite;
+
+use OpenApi\Attributes as OA;
+
+// 显式指定了 schema 名称，用于测试 schema name formatting 不覆盖手动命名的场景
+#[OA\Schema(schema: 'ExplicitlyNamed')]
+class ExplicitNamedSchema
+{
+    #[OA\Property(type: 'string')]
+    public string $name;
+}

--- a/tests/Fixtures/Swagger/Overwrite/PlainDtoClass.php
+++ b/tests/Fixtures/Swagger/Overwrite/PlainDtoClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Fixtures\Swagger\Overwrite;
+
+use WebmanTech\DTO\BaseDTO;
+
+// 故意不添加 #[Schema] 和 #[Property] 注解，用于测试 AttributeAnnotationFactory 的自动生成能力
+class PlainDtoClass extends BaseDTO
+{
+    public string $name;
+    public int $age;
+    protected string $secret;
+    private float $hidden;
+}

--- a/tests/Fixtures/Swagger/Overwrite/PlainEnum.php
+++ b/tests/Fixtures/Swagger/Overwrite/PlainEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Fixtures\Swagger\Overwrite;
+
+// 故意不添加 #[Schema] 注解，用于测试 AttributeAnnotationFactory 的自动生成能力
+enum PlainEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+}

--- a/tests/Fixtures/Swagger/Overwrite/PlainUnitEnum.php
+++ b/tests/Fixtures/Swagger/Overwrite/PlainUnitEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Fixtures\Swagger\Overwrite;
+
+// Unit Enum（无 backing type），用于测试 AttributeAnnotationFactory 对无值枚举的处理
+enum PlainUnitEnum
+{
+    case X;
+    case Y;
+}

--- a/tests/Fixtures/Swagger/TestFactory.php
+++ b/tests/Fixtures/Swagger/TestFactory.php
@@ -7,18 +7,28 @@ use OpenApi\Analysers\ReflectionAnalyser;
 use OpenApi\Analysis;
 use OpenApi\Context;
 use OpenApi\Generator;
+use OpenApi\Pipeline;
 
 class TestFactory
 {
-    public static function analysisFromFiles(array $files): Analysis
+    /**
+     * @param array<string>                                     $files
+     * @param callable(\OpenApi\Generator): void|null           $configureGenerator
+     */
+    public static function analysisFromFiles(array $files, ?callable $configureGenerator = null): Analysis
     {
         $analysis = new Analysis([], new Context());
 
-        (new Generator())
+        $generator = (new Generator())
             ->setAnalyser(new ReflectionAnalyser([
                 new AttributeAnnotationFactory()
-            ]))
-            ->generate(array_map(fn($file) => fixture_get_path('Swagger/' . $file), $files), $analysis, false);
+            ]));
+
+        if ($configureGenerator) {
+            $configureGenerator($generator);
+        }
+
+        $generator->generate(array_map(fn($file) => fixture_get_path('Swagger/' . $file), $files), $analysis, false);
 
         return $analysis;
     }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -112,12 +112,11 @@ function normalizeOpenApiPaths(string $body, string $format): string
         return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
     }
 
-    // YAML: 解析后排序 paths 再输出
+    // YAML: 解析后排序 paths，统一用 JSON 输出以消除不同 symfony/yaml 版本间的序列化格式差异
+    // （如空对象 `{  }` vs `{}`、列表项多行 vs 内联等）
     $data = \Symfony\Component\Yaml\Yaml::parse($body);
     if (isset($data['paths'])) {
         $data['paths'] = collect($data['paths'])->sortKeys()->toArray();
     }
-    $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 6, 2, \Symfony\Component\Yaml\Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
-    // 归一化空对象/空数组的内联表示，消除不同 symfony/yaml 版本间的格式差异（如 `{  }` vs `{}`）
-    return strtr($yaml, ['{  }' => '{}', '[ ]' => '[]']);
+    return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -117,5 +117,7 @@ function normalizeOpenApiPaths(string $body, string $format): string
     if (isset($data['paths'])) {
         $data['paths'] = collect($data['paths'])->sortKeys()->toArray();
     }
-    return \Symfony\Component\Yaml\Yaml::dump($data, 6, 2, \Symfony\Component\Yaml\Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+    $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 6, 2, \Symfony\Component\Yaml\Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+    // 归一化空对象/空数组的内联表示，消除不同 symfony/yaml 版本间的格式差异（如 `{  }` vs `{}`）
+    return strtr($yaml, ['{  }' => '{}', '[ ]' => '[]']);
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -83,6 +83,23 @@ function request_get_raw(Request $request): TestRequest
 }
 
 /**
+ * @param class-string|Closure|object|array<class-string|Closure|object> $processor
+ */
+function swagger_processor_analyse($processor, \OpenApi\Analysis $analysis, bool $setGenerator = true, ?\OpenApi\Generator $generator = null): void
+{
+    $processors = is_array($processor) ? $processor : [$processor];
+    foreach ($processors as $processor) {
+        if (is_string($processor)) {
+            $processor = new $processor;
+        }
+        if ($setGenerator && method_exists($processor, 'setGenerator')) {
+            $processor->setGenerator($generator ?? new \OpenApi\Generator());
+        }
+        $processor($analysis);
+    }
+}
+
+/**
  * 对 OpenAPI 文档的 paths 进行排序，消除不同环境下文件扫描顺序不一致导致的 snapshot 差异
  */
 function normalizeOpenApiPaths(string $body, string $format): string

--- a/tests/Unit/Swagger/Overwrite/OverwriteTest.php
+++ b/tests/Unit/Swagger/Overwrite/OverwriteTest.php
@@ -1,0 +1,488 @@
+<?php
+
+use OpenApi\Annotations as OA;
+use OpenApi\Context;
+use OpenApi\Generator;
+use Tests\Fixtures\Swagger\EnumColor;
+use Tests\Fixtures\Swagger\Overwrite\ClassWithMissingType;
+use Tests\Fixtures\Swagger\Overwrite\ClassWithStaticProp;
+use Tests\Fixtures\Swagger\Overwrite\ExplicitNamedSchema;
+use Tests\Fixtures\Swagger\Overwrite\PlainDtoClass;
+use Tests\Fixtures\Swagger\Overwrite\PlainEnum;
+use Tests\Fixtures\Swagger\Overwrite\PlainUnitEnum;
+use Tests\Fixtures\Swagger\SchemaA;
+use Tests\Fixtures\Swagger\TestFactory;
+use WebmanTech\DTO\BaseDTO;
+use WebmanTech\Swagger\DTO\ConfigOpenapiDocDTO;
+use WebmanTech\Swagger\Overwrite as OW;
+
+// ===========================================
+// Schema Name Formatting（Schema 名称格式化）
+// ===========================================
+
+test('Generator formatSchemaName applies custom formatter to unnamed schemas', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+        schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    $schemaNames = collect($openapi->components->schemas)
+        ->map(fn(OA\Schema $s) => $schemaName = $s->schema)
+        ->toArray();
+
+    expect($schemaNames)->toContain('CustomSchemaA');
+});
+
+test('Generator formatSchemaName preserves explicitly named schemas', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/Overwrite/ExplicitNamedSchema.php')],
+        schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    $schema = collect($openapi->components->schemas)
+        ->first(fn(OA\Schema $s) => SwaggerHelper_getSchemaName($s) === 'ExplicitlyNamed');
+
+    expect($schema)->not->toBeNull()
+        ->and($schema->schema)->toBe('ExplicitlyNamed');
+});
+
+test('Generator formatSchemaName does nothing when disabled', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+        schema_name_format_use_classname: null,
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    $schema = collect($openapi->components->schemas)->first();
+    expect($schema)->not->toBeNull()
+        ->and($schema->schema)->toBe('SchemaA');
+});
+
+test('AugmentSchemas processor formats root unnamed schemas', function () {
+    $formatted = [];
+    $formatter = function (OA\Schema $schema) use (&$formatted) {
+        $formatted[] = SwaggerHelper_getSchemaName($schema);
+        $schema->schema = 'Formatted_' . $schema->_context->class;
+    };
+
+    $analysis = TestFactory::analysisFromFiles(['SchemaA.php']);
+    // TestFactory 已跑过完整 pipeline，schema 已有名称，需重置为 UNDEFINED 才能触发格式化
+    $schema = $analysis->getSchemaForSource(SchemaA::class);
+    $schema->schema = Generator::UNDEFINED;
+
+    $analysis->process(new OW\Processors\AugmentSchemas($formatter));
+
+    expect($formatted)->toContain('');
+    expect($schema->schema)->toBe('Formatted_SchemaA');
+});
+
+test('ExpandEnums processor formats enum schemas before expansion', function () {
+    $formatted = [];
+    $formatter = function (OA\Schema $schema) use (&$formatted) {
+        $formatted[] = SwaggerHelper_getSchemaName($schema);
+        $schema->schema = 'FormattedEnum_' . $schema->_context->enum;
+    };
+
+    $analysis = TestFactory::analysisFromFiles(['EnumColor.php']);
+    // 重置 schema 名称以触发格式化
+    $schema = $analysis->getSchemaForSource(EnumColor::class);
+    $schema->schema = Generator::UNDEFINED;
+
+    $analysis->process([
+        new OW\Processors\ExpandEnums($formatter),
+    ]);
+
+    expect($formatted)->toContain('');
+    expect($schema->schema)->toBe('FormattedEnum_EnumColor');
+});
+
+// ===========================================
+// Auto Schema/Property Generation（AttributeAnnotationFactory）
+// ===========================================
+
+test('AttributeAnnotationFactory auto Schema for enum', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory();
+    $context = new Context(['enum' => 'PlainEnum']);
+    $reflector = new ReflectionClass(PlainEnum::class);
+
+    $annotations = $factory->build($reflector, $context);
+
+    $schemas = array_filter($annotations, fn($a) => $a instanceof OA\Schema);
+    expect($schemas)->toHaveCount(1);
+
+    $schema = reset($schemas);
+    // 枚举应有 string 类型（因为是 BackedEnum: string）
+    expect($schema->type)->toBe('string');
+});
+
+test('AttributeAnnotationFactory auto Schema for supported class', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'PlainDtoClass']);
+    $reflector = new ReflectionClass(PlainDtoClass::class);
+
+    $annotations = $factory->build($reflector, $context);
+
+    $schemas = array_filter($annotations, fn($a) => $a instanceof OA\Schema);
+    expect($schemas)->toHaveCount(1);
+});
+
+test('AttributeAnnotationFactory no auto Schema for unsupported class', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'stdClass']);
+    $reflector = new ReflectionClass(\stdClass::class);
+
+    $annotations = $factory->build($reflector, $context);
+
+    $schemas = array_filter($annotations, fn($a) => $a instanceof OA\Schema);
+    expect($schemas)->toHaveCount(0);
+});
+
+test('AttributeAnnotationFactory no auto Schema when explicit annotation exists', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory();
+    $context = new Context(['enum' => 'EnumColor']);
+    $reflector = new ReflectionClass(EnumColor::class);
+
+    $annotations = $factory->build($reflector, $context);
+
+    // EnumColor 已有 #[OA\Schema(description: '颜色枚举')]，不会自动生成额外的 Schema
+    // 父类 parent::build() 会解析出该注解，所以只有 1 个来自显式注解的 Schema
+    $schemas = array_filter($annotations, fn($a) => $a instanceof OA\Schema);
+    expect($schemas)->toHaveCount(1);
+    $schema = reset($schemas);
+    // 验证是来自显式注解（有 description），而非自动生成（无 description）
+    expect($schema->description)->toBe('颜色枚举');
+});
+
+test('AttributeAnnotationFactory auto Property for public non-static props', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'PlainDtoClass', 'property' => 'name']);
+
+    $reflector = new ReflectionProperty(PlainDtoClass::class, 'name');
+    $annotations = $factory->build($reflector, $context);
+
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(1);
+});
+
+test('AttributeAnnotationFactory no auto Property for protected prop', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'PlainDtoClass', 'property' => 'secret']);
+
+    $reflector = new ReflectionProperty(PlainDtoClass::class, 'secret');
+    $annotations = $factory->build($reflector, $context);
+
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(0);
+});
+
+test('AttributeAnnotationFactory no auto Property for private prop', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'PlainDtoClass', 'property' => 'hidden']);
+
+    $reflector = new ReflectionProperty(PlainDtoClass::class, 'hidden');
+    $annotations = $factory->build($reflector, $context);
+
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(0);
+});
+
+test('AttributeAnnotationFactory no auto Property when explicit annotation exists', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory();
+    $context = new Context(['class' => 'SchemaA', 'property' => 'name']);
+
+    $reflector = new ReflectionProperty(SchemaA::class, 'name');
+    $annotations = $factory->build($reflector, $context);
+
+    // SchemaA::$name 已有 #[OA\Property]，不应自动生成额外的
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(0);
+});
+
+// ===========================================
+// ReflectionAnalyser（错误容忍）
+// ===========================================
+
+test('ReflectionAnalyser handles valid class without error', function () {
+    $analyser = new OW\ReflectionAnalyser([
+        new \OpenApi\Analysers\AttributeAnnotationFactory(),
+    ]);
+    $analysis = new \OpenApi\Analysis([], new Context());
+
+    $method = new ReflectionMethod($analyser, 'analyzeFqdn');
+    $details = [
+        'uses' => [],
+        'interfaces' => [],
+        'traits' => [],
+        'properties' => [],
+        'methods' => [],
+    ];
+    $result = $method->invoke($analyser, EnumColor::class, $analysis, $details);
+
+    expect($result)->toBe($analysis);
+});
+
+test('ReflectionAnalyser skips non-existent class gracefully', function () {
+    // 父类 analyzeFqdn 在 line 87 先检查 class_exists，不存在的类直接跳过
+    // 所以 Overwrite 的 try-catch 是用于分析过程中遇到的 Class not found 错误
+    // 这种场景难以直接单元测试，此处仅验证对不存在类不会抛异常
+    $analyser = new OW\ReflectionAnalyser([
+        new \OpenApi\Analysers\AttributeAnnotationFactory(),
+    ]);
+    $analysis = new \OpenApi\Analysis([], new Context());
+
+    $method = new ReflectionMethod($analyser, 'analyzeFqdn');
+    $result = $method->invoke($analyser, 'CompletelyNonExistentClass12345', $analysis, []);
+
+    expect($result)->toBe($analysis);
+});
+
+test('ReflectionAnalyser Class not found pattern matching', function () {
+    // 验证 catch 条件对典型错误消息的匹配
+    $classNotFound = "Class 'SomeClass' not found";
+    expect(str_contains($classNotFound, 'Class') && str_contains($classNotFound, 'not found'))->toBeTrue();
+
+    $classNotExist = "Class SomeClass does not exist";
+    expect(str_contains($classNotExist, 'Class') && str_contains($classNotExist, 'not found'))->toBeFalse();
+
+    $unrelated = "Something went wrong";
+    expect(str_contains($unrelated, 'Class') && str_contains($unrelated, 'not found'))->toBeFalse();
+});
+
+// ===========================================
+// Integration（集成测试）
+// ===========================================
+
+test('full pipeline with schema name formatting produces correct output', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/Overwrite/PlainDtoClass.php')],
+        schema_name_format_use_classname: fn(string $className) => basename(str_replace('\\', '/', $className)),
+        format: 'json',
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    // PlainDtoClass 没有 #[Schema] 注解，但通过 autoLoadSchemaClasses 应该被自动加载
+    $schemas = $openapi->components->schemas;
+    expect($schemas)->not->toBeEmpty();
+
+    // schema name 应被格式化
+    $schema = collect($schemas)->first();
+    expect($schema->schema)->toBe('PlainDtoClass');
+
+    // public 属性应该被自动生成 Property
+    $propertyNames = collect($schema->properties ?? [])
+        ->map(fn(OA\Property $p) => $p->property)
+        ->toArray();
+    expect($propertyNames)->toContain('name', 'age')
+        ->and($propertyNames)->not->toContain('secret', 'hidden');
+});
+
+test('full pipeline with enum schema name formatting', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/Overwrite/PlainEnum.php')],
+        schema_name_format_use_classname: fn(string $className) => 'Custom_' . basename(str_replace('\\', '/', $className)),
+        format: 'json',
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    $schema = collect($openapi->components->schemas)->first();
+    expect($schema->schema)->toBe('Custom_PlainEnum')
+        ->and($schema->type)->toBe('string')
+        ->and($schema->enum)->toBe(['a', 'b']);
+});
+
+// ===========================================
+// 补充：Generator 默认 Str 格式化路径
+// ===========================================
+
+test('Generator formatSchemaName with true uses default Str formatter', function () {
+    // schema_name_format_use_classname: true（非 Closure）走 Str::studly 默认格式化
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+        schema_name_format_use_classname: true,
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    $schema = collect($openapi->components->schemas)->first();
+    // Tests\Fixtures\Swagger\SchemaA → Tests Fixtures Swagger SchemaA → TestsFixturesSwaggerSchemaA
+    expect($schema->schema)->toBe('TestsFixturesSwaggerSchemaA');
+});
+
+test('Generator getOpenapiDocConfig returns config', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+    );
+    $generator = new OW\Generator($config);
+
+    expect($generator->getOpenapiDocConfig())->toBe($config);
+});
+
+test('Generator generate with non-Overwrite Analysis still works', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+        schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
+    );
+    $generator = new OW\Generator($config);
+
+    // 传入原生 Analysis（非 Overwrite\Analysis），generate 仍应正常完成
+    // 格式化通过 Processor 管线（AugmentSchemas/ExpandEnums）触发，不依赖 Analysis hook
+    $nativeAnalysis = new \OpenApi\Analysis([], new Context());
+    $openapi = $generator->init()->generate($config->getScanSources(), $nativeAnalysis);
+
+    // Processor 管线中的格式化仍然生效
+    $schema = collect($openapi->components->schemas)->first();
+    expect($schema->schema)->toBe('CustomSchemaA');
+});
+
+// ===========================================
+// 补充：AttributeAnnotationFactory 边界
+// ===========================================
+
+test('AttributeAnnotationFactory auto Schema for unit enum defaults to string type', function () {
+    // Unit enum（无 backing type）应默认类型为 string
+    $factory = new OW\Analysers\AttributeAnnotationFactory();
+    $context = new Context(['enum' => 'PlainUnitEnum']);
+    $reflector = new ReflectionClass(PlainUnitEnum::class);
+
+    $annotations = $factory->build($reflector, $context);
+
+    $schemas = array_filter($annotations, fn($a) => $a instanceof OA\Schema);
+    expect($schemas)->toHaveCount(1);
+
+    $schema = reset($schemas);
+    expect($schema->type)->toBe('string');
+});
+
+test('AttributeAnnotationFactory no auto Property for static prop', function () {
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'ClassWithStaticProp', 'property' => 'staticName']);
+
+    $reflector = new ReflectionProperty(ClassWithStaticProp::class, 'staticName');
+    $annotations = $factory->build($reflector, $context);
+
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(0);
+});
+
+test('AttributeAnnotationFactory auto Property for public prop alongside static', function () {
+    // 同一个类中 public 非 static 属性应正常生成
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [BaseDTO::class],
+    );
+    $context = new Context(['class' => 'ClassWithStaticProp', 'property' => 'name']);
+
+    $reflector = new ReflectionProperty(ClassWithStaticProp::class, 'name');
+    $annotations = $factory->build($reflector, $context);
+
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(1);
+});
+
+test('AttributeAnnotationFactory no auto Property for unsupported class public prop', function () {
+    // autoLoadSchemaClasses 为空，PlainDtoClass 虽然有 public 属性但不在支持列表中
+    $factory = new OW\Analysers\AttributeAnnotationFactory(
+        autoLoadSchemaClasses: [],
+    );
+    $context = new Context(['class' => 'PlainDtoClass', 'property' => 'name']);
+
+    $reflector = new ReflectionProperty(PlainDtoClass::class, 'name');
+    $annotations = $factory->build($reflector, $context);
+
+    $properties = array_filter($annotations, fn($a) => $a instanceof OA\Property);
+    expect($properties)->toHaveCount(0);
+});
+
+// ===========================================
+// 补充：ReflectionAnalyser catch 块真实触发
+// ===========================================
+
+test('ReflectionAnalyser catches Class not found during analysis', function () {
+    // 注册一个会在 class_exists 时抛出 "Class 'X' not found" 的 autoloader
+    $throwingAutoloader = function (string $class) {
+        if (str_starts_with($class, 'NonExistent\\')) {
+            throw new \Error("Class '{$class}' not found");
+        }
+    };
+    spl_autoload_register($throwingAutoloader);
+
+    try {
+        $analyser = new OW\ReflectionAnalyser([
+            new \OpenApi\Analysers\AttributeAnnotationFactory(),
+        ]);
+        $analysis = new \OpenApi\Analysis([], new Context());
+
+        $method = new ReflectionMethod($analyser, 'analyzeFqdn');
+        $method->invoke($analyser, ClassWithMissingType::class, $analysis, [
+            'uses' => [],
+            'interfaces' => [],
+            'traits' => [],
+            'properties' => ['missing'],
+            'methods' => [],
+        ]);
+
+        // 应不抛异常，静默忽略 Class not found
+        expect(true)->toBeTrue();
+    } finally {
+        spl_autoload_unregister($throwingAutoloader);
+    }
+});
+
+// ===========================================
+// 补充：Analysis 边界
+// ===========================================
+
+test('Analysis getSchemaForSource without formatter works as parent', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+        schema_name_format_use_classname: null, // 不启用格式化
+    );
+    $generator = new OW\Generator($config);
+    $openapi = $generator->init()->generate($config->getScanSources());
+
+    // 不启用格式化时，schema 名称保持 swagger-php 默认行为
+    $schema = collect($openapi->components->schemas)->first();
+    expect($schema->schema)->toBe('SchemaA');
+});
+
+test('Analysis getSchemaForSource returns null for unknown FQDN', function () {
+    $config = new ConfigOpenapiDocDTO(
+        scan_path: [fixture_get_path('Swagger/SchemaA.php')],
+        schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
+    );
+    $generator = new OW\Generator($config);
+    // generate 会创建 Overwrite\Analysis 内部实例
+    $generator->init()->generate($config->getScanSources());
+
+    // 通过 TestFactory 获取 analysis 来测试 getSchemaForSource 对不存在 FQDN 的处理
+    $analysis = TestFactory::analysisFromFiles(['SchemaA.php']);
+    $result = $analysis->getSchemaForSource('NonExistentClass');
+    expect($result)->toBeNull();
+});
+
+// ===========================================
+// Helper
+// ===========================================
+
+function SwaggerHelper_getSchemaName(OA\Schema $schema): string
+{
+    return Generator::isDefault($schema->schema) ? '' : $schema->schema;
+}

--- a/tests/Unit/Swagger/Overwrite/OverwriteTest.php
+++ b/tests/Unit/Swagger/Overwrite/OverwriteTest.php
@@ -3,6 +3,7 @@
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use OpenApi\Generator;
+use Psr\Log\NullLogger;
 use Tests\Fixtures\Swagger\EnumColor;
 use Tests\Fixtures\Swagger\Overwrite\ClassWithMissingType;
 use Tests\Fixtures\Swagger\Overwrite\ClassWithStaticProp;
@@ -26,7 +27,7 @@ test('Generator formatSchemaName applies custom formatter to unnamed schemas', f
         schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     $schemaNames = collect($openapi->components->schemas)
         ->map(fn(OA\Schema $s) => $schemaName = $s->schema)
@@ -41,7 +42,7 @@ test('Generator formatSchemaName preserves explicitly named schemas', function (
         schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     $schema = collect($openapi->components->schemas)
         ->first(fn(OA\Schema $s) => SwaggerHelper_getSchemaName($s) === 'ExplicitlyNamed');
@@ -56,7 +57,7 @@ test('Generator formatSchemaName does nothing when disabled', function () {
         schema_name_format_use_classname: null,
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     $schema = collect($openapi->components->schemas)->first();
     expect($schema)->not->toBeNull()
@@ -72,10 +73,10 @@ test('AugmentSchemas processor formats root unnamed schemas', function () {
 
     $analysis = TestFactory::analysisFromFiles(['SchemaA.php']);
     // TestFactory 已跑过完整 pipeline，schema 已有名称，需重置为 UNDEFINED 才能触发格式化
-    $schema = $analysis->getSchemaForSource(SchemaA::class);
+    $schema = $analysis->getAnnotationForSource(SchemaA::class);
     $schema->schema = Generator::UNDEFINED;
 
-    $analysis->process(new OW\Processors\AugmentSchemas($formatter));
+    swagger_processor_analyse(new OW\Processors\AugmentSchemas($formatter), $analysis);
 
     expect($formatted)->toContain('');
     expect($schema->schema)->toBe('Formatted_SchemaA');
@@ -90,12 +91,10 @@ test('ExpandEnums processor formats enum schemas before expansion', function () 
 
     $analysis = TestFactory::analysisFromFiles(['EnumColor.php']);
     // 重置 schema 名称以触发格式化
-    $schema = $analysis->getSchemaForSource(EnumColor::class);
+    $schema = $analysis->getAnnotationForSource(EnumColor::class);
     $schema->schema = Generator::UNDEFINED;
 
-    $analysis->process([
-        new OW\Processors\ExpandEnums($formatter),
-    ]);
+    swagger_processor_analyse(new OW\Processors\ExpandEnums($formatter), $analysis);
 
     expect($formatted)->toContain('');
     expect($schema->schema)->toBe('FormattedEnum_EnumColor');
@@ -107,6 +106,7 @@ test('ExpandEnums processor formats enum schemas before expansion', function () 
 
 test('AttributeAnnotationFactory auto Schema for enum', function () {
     $factory = new OW\Analysers\AttributeAnnotationFactory();
+    $factory->setGenerator(new Generator());
     $context = new Context(['enum' => 'PlainEnum']);
     $reflector = new ReflectionClass(PlainEnum::class);
 
@@ -221,7 +221,9 @@ test('ReflectionAnalyser handles valid class without error', function () {
     $analyser = new OW\ReflectionAnalyser([
         new \OpenApi\Analysers\AttributeAnnotationFactory(),
     ]);
-    $analysis = new \OpenApi\Analysis([], new Context());
+    $analysis = new \OpenApi\Analysis([], new Context([
+        'logger' => new NullLogger(),
+    ]));
 
     $method = new ReflectionMethod($analyser, 'analyzeFqdn');
     $details = [
@@ -243,7 +245,9 @@ test('ReflectionAnalyser skips non-existent class gracefully', function () {
     $analyser = new OW\ReflectionAnalyser([
         new \OpenApi\Analysers\AttributeAnnotationFactory(),
     ]);
-    $analysis = new \OpenApi\Analysis([], new Context());
+    $analysis = new \OpenApi\Analysis([], new Context([
+        'logger' => new NullLogger(),
+    ]));
 
     $method = new ReflectionMethod($analyser, 'analyzeFqdn');
     $result = $method->invoke($analyser, 'CompletelyNonExistentClass12345', $analysis, []);
@@ -274,7 +278,7 @@ test('full pipeline with schema name formatting produces correct output', functi
         format: 'json',
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     // PlainDtoClass 没有 #[Schema] 注解，但通过 autoLoadSchemaClasses 应该被自动加载
     $schemas = $openapi->components->schemas;
@@ -299,7 +303,7 @@ test('full pipeline with enum schema name formatting', function () {
         format: 'json',
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     $schema = collect($openapi->components->schemas)->first();
     expect($schema->schema)->toBe('Custom_PlainEnum')
@@ -318,7 +322,7 @@ test('Generator formatSchemaName with true uses default Str formatter', function
         schema_name_format_use_classname: true,
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     $schema = collect($openapi->components->schemas)->first();
     // Tests\Fixtures\Swagger\SchemaA → Tests Fixtures Swagger SchemaA → TestsFixturesSwaggerSchemaA
@@ -344,7 +348,7 @@ test('Generator generate with non-Overwrite Analysis still works', function () {
     // 传入原生 Analysis（非 Overwrite\Analysis），generate 仍应正常完成
     // 格式化通过 Processor 管线（AugmentSchemas/ExpandEnums）触发，不依赖 Analysis hook
     $nativeAnalysis = new \OpenApi\Analysis([], new Context());
-    $openapi = $generator->init()->generate($config->getScanSources(), $nativeAnalysis);
+    $openapi = $generator->init()->generate($config->getScanSources(), $nativeAnalysis, false);
 
     // Processor 管线中的格式化仍然生效
     $schema = collect($openapi->components->schemas)->first();
@@ -358,6 +362,7 @@ test('Generator generate with non-Overwrite Analysis still works', function () {
 test('AttributeAnnotationFactory auto Schema for unit enum defaults to string type', function () {
     // Unit enum（无 backing type）应默认类型为 string
     $factory = new OW\Analysers\AttributeAnnotationFactory();
+    $factory->setGenerator(new Generator());
     $context = new Context(['enum' => 'PlainUnitEnum']);
     $reflector = new ReflectionClass(PlainUnitEnum::class);
 
@@ -450,31 +455,31 @@ test('ReflectionAnalyser catches Class not found during analysis', function () {
 // 补充：Analysis 边界
 // ===========================================
 
-test('Analysis getSchemaForSource without formatter works as parent', function () {
+test('Analysis getAnnotationForSource without formatter works as parent', function () {
     $config = new ConfigOpenapiDocDTO(
         scan_path: [fixture_get_path('Swagger/SchemaA.php')],
         schema_name_format_use_classname: null, // 不启用格式化
     );
     $generator = new OW\Generator($config);
-    $openapi = $generator->init()->generate($config->getScanSources());
+    $openapi = $generator->init()->generate($config->getScanSources(), validate: false);
 
     // 不启用格式化时，schema 名称保持 swagger-php 默认行为
     $schema = collect($openapi->components->schemas)->first();
     expect($schema->schema)->toBe('SchemaA');
 });
 
-test('Analysis getSchemaForSource returns null for unknown FQDN', function () {
+test('Analysis getAnnotationForSource returns null for unknown FQDN', function () {
     $config = new ConfigOpenapiDocDTO(
         scan_path: [fixture_get_path('Swagger/SchemaA.php')],
         schema_name_format_use_classname: fn(string $className) => 'Custom' . basename(str_replace('\\', '/', $className)),
     );
     $generator = new OW\Generator($config);
     // generate 会创建 Overwrite\Analysis 内部实例
-    $generator->init()->generate($config->getScanSources());
+    $generator->init()->generate($config->getScanSources(), validate: false);
 
-    // 通过 TestFactory 获取 analysis 来测试 getSchemaForSource 对不存在 FQDN 的处理
+    // 通过 TestFactory 获取 analysis 来测试 getAnnotationForSource 对不存在 FQDN 的处理
     $analysis = TestFactory::analysisFromFiles(['SchemaA.php']);
-    $result = $analysis->getSchemaForSource('NonExistentClass');
+    $result = $analysis->getAnnotationForSource('NonExistentClass');
     expect($result)->toBeNull();
 });
 

--- a/tests/Unit/Swagger/RouteAnnotation/ProcessorTest.php
+++ b/tests/Unit/Swagger/RouteAnnotation/ProcessorTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Arr;
 use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 use Tests\Fixtures\Swagger\ControllerForXSchemaRequestSchemaA;
 use Tests\Fixtures\Swagger\ControllerForXSchemaRequestSchemaB;
 use Tests\Fixtures\Swagger\ControllerForXSchemaRequestSchemaC;
@@ -15,6 +16,7 @@ use Tests\Fixtures\Swagger\SchemaEloquentVisibleModel;
 use Tests\Fixtures\Swagger\TestFactory;
 use Webman\Http\UploadFile;
 use WebmanTech\Swagger\DTO\SchemaConstants;
+use WebmanTech\Swagger\Helper\SwaggerHelper;
 use WebmanTech\Swagger\RouteAnnotation\Processors\AppendResponseProcessor;
 use WebmanTech\Swagger\RouteAnnotation\Processors\ExpandDTOAttributionsProcessor;
 use WebmanTech\Swagger\RouteAnnotation\Processors\ExpandEloquentModelProcessor;
@@ -25,12 +27,11 @@ use WebmanTech\Swagger\RouteAnnotation\Processors\XDiscriminatorProcessor;
 use WebmanTech\Swagger\RouteAnnotation\Processors\XSchemaRequestProcessor;
 use WebmanTech\Swagger\RouteAnnotation\Processors\XSchemaResponseProcessor;
 
+
 test('SortComponentsProcessor', function () {
     $analysis = TestFactory::analysisFromFiles(['SchemaA.php', 'SchemaB.php']);
 
-    $analysis->process(
-        new SortComponentsProcessor(),
-    );
+    swagger_processor_analyse(SortComponentsProcessor::class, $analysis);
 
     expect(collect($analysis->openapi->components->schemas)->pluck('schema'))
         ->toMatchArray(['SchemaA', 'SchemaB']);
@@ -39,19 +40,23 @@ test('SortComponentsProcessor', function () {
 test('AppendResponseProcessor', function () {
     $analysis = TestFactory::analysisFromFiles(['ControllerNoResponse.php']);
 
-    $analysis->process(
-        new AppendResponseProcessor(),
-    );
+    swagger_processor_analyse(AppendResponseProcessor::class, $analysis);
 
-    expect($analysis->openapi->paths[0]->get->responses[200])->not->toBeEmpty();
+    expect($analysis->openapi->paths[0]->get->responses[0])->not->toBeEmpty()
+        ->and($analysis->openapi->paths[0]->get->responses[0]->response)->toBe(200);
 });
 
 test('MergeClassInfoProcessor', function () {
-    $analysis = TestFactory::analysisFromFiles(['ControllerWithInfo.php']);
+    // AugmentTags 默认会清理未被 operation 引用的 class 级别 tag，
+    // 生产环境（Overwrite\Generator）会将其调整到 MergeClassInfoProcessor 之后执行，
+    // 这里对齐该行为：先移除 AugmentTags，由 MergeClassInfoProcessor 将 class tag 合并到 operation 后再手动触发。
+    $analysis = TestFactory::analysisFromFiles(['ControllerWithInfo.php'], function (\OpenApi\Generator $generator): void {
+        $generator->withProcessorPipeline(function (\OpenApi\Pipeline $pipeline): void {
+            $pipeline->remove(\OpenApi\Processors\AugmentTags::class);
+        });
+    });
 
-    $analysis->process(
-        new MergeClassInfoProcessor(),
-    );
+    swagger_processor_analyse(MergeClassInfoProcessor::class, $analysis);
 
     // tag
     expect($analysis->openapi->paths[0]->get->tags)->toBe(['controller'])
@@ -63,9 +68,7 @@ test('MergeClassInfoProcessor', function () {
 test('XSchemaRequestProcessor', function () {
     $analysis = TestFactory::analysisFromFiles(['ControllerForXSchemaRequest.php']);
 
-    $analysis->process(
-        new XSchemaRequestProcessor(),
-    );
+    swagger_processor_analyse(XSchemaRequestProcessor::class, $analysis);
 
     $fnFindPathItemByPath = function (string $path, string $method) use ($analysis): OA\Operation {
         return collect($analysis->openapi->paths)
@@ -114,9 +117,7 @@ test('XSchemaRequestProcessor', function () {
 test('XSchemaResponseProcessor', function () {
     $analysis = TestFactory::analysisFromFiles(['ControllerForXSchemaResponse.php']);
 
-    $analysis->process(
-        new XSchemaResponseProcessor(),
-    );
+    swagger_processor_analyse(XSchemaResponseProcessor::class, $analysis);
 
     $fnFindPathItemByPath = function (string $path, string $method) use ($analysis): OA\Operation {
         return collect($analysis->openapi->paths)
@@ -128,13 +129,13 @@ test('XSchemaResponseProcessor', function () {
 
     // 单 string 类，转到 200 上
     $operation = $fnFindPathItemByPath('/get/schema', 'get');
-    expect($operation->responses[200]->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaA')
+    expect(SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaA')
         ->and($operation->x)->toBe(\OpenApi\Generator::UNDEFINED); // 用完被清理
 
     // 多维 index 数组，转到 200 上
     $operation = $fnFindPathItemByPath('/get/schema-multi', 'get');
-    expect($operation->responses[200]->content['application/json']->schema->allOf)->toHaveCount(2);
-    $allOfRefs = array_map(fn(OA\Schema $schema) => $schema->ref, $operation->responses[200]->content['application/json']->schema->allOf);
+    expect(SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->allOf)->toHaveCount(2);
+    $allOfRefs = array_map(fn(OA\Schema $schema) => $schema->ref, SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->allOf);
     expect($allOfRefs)->toBe([
         '#/components/schemas/ControllerForXSchemaResponseSchemaA',
         '#/components/schemas/ControllerForXSchemaResponseSchemaB',
@@ -142,8 +143,8 @@ test('XSchemaResponseProcessor', function () {
 
     // 多维 index 数组，转到 200 上 -- 使用 oneOf
     $operation = $fnFindPathItemByPath('/get/schema-multi-oneOf', 'get');
-    expect($operation->responses[200]->content['application/json']->schema->oneOf)->toHaveCount(2);
-    $allOfRefs = array_map(fn(OA\Schema $schema) => $schema->ref, $operation->responses[200]->content['application/json']->schema->oneOf);
+    expect(SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->oneOf)->toHaveCount(2);
+    $allOfRefs = array_map(fn(OA\Schema $schema) => $schema->ref, SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->oneOf);
     expect($allOfRefs)->toBe([
         '#/components/schemas/ControllerForXSchemaResponseSchemaA',
         '#/components/schemas/ControllerForXSchemaResponseSchemaB',
@@ -151,14 +152,14 @@ test('XSchemaResponseProcessor', function () {
 
     // status_code 单 string
     $operation = $fnFindPathItemByPath('/get/schema-status-code', 'get');
-    expect($operation->responses[200]->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaA')
-        ->and($operation->responses[201]->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaB');
+    expect(SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaA')
+        ->and(SwaggerHelper::getOperationResponse($operation, 201)->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaB');
 
     // status_code 数组
     $operation = $fnFindPathItemByPath('/get/schema-status-code-multi', 'get');
-    expect($operation->responses[200]->content['application/json']->schema->allOf)->toHaveCount(2)
-        ->and($operation->responses[201]->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaB');
-    $allOfRefs = array_map(fn(OA\Schema $schema) => $schema->ref, $operation->responses[200]->content['application/json']->schema->allOf);
+    expect(SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->allOf)->toHaveCount(2)
+        ->and(SwaggerHelper::getOperationResponse($operation, 201)->content['application/json']->schema->ref)->toBe('#/components/schemas/ControllerForXSchemaResponseSchemaB');
+    $allOfRefs = array_map(fn(OA\Schema $schema) => $schema->ref, SwaggerHelper::getOperationResponse($operation, 200)->content['application/json']->schema->allOf);
     expect($allOfRefs)->toBe([
         '#/components/schemas/ControllerForXSchemaResponseSchemaA',
         '#/components/schemas/ControllerForXSchemaResponseSchemaB',
@@ -168,12 +169,10 @@ test('XSchemaResponseProcessor', function () {
 test('ExpandDTOAttributionsProcessor', function () {
     $analysis = TestFactory::analysisFromFiles(['SchemaDTO.php']);
 
-    $analysis->process(
-        new ExpandDTOAttributionsProcessor(),
-    );
+    swagger_processor_analyse(ExpandDTOAttributionsProcessor::class, $analysis);
 
-    $schema = $analysis->getSchemaForSource(SchemaDTO::class);
-    $schemaChild = $analysis->getSchemaForSource(SchemaDTOChild::class);
+    $schema = $analysis->getAnnotationForSource(SchemaDTO::class);
+    $schemaChild = $analysis->getAnnotationForSource(SchemaDTOChild::class);
     $fnFindPropertyByName = function (string $propertyName) use ($schema): OA\Property {
         return Arr::first($schema->properties, fn(OA\Property $property) => $property->property === $propertyName);
     };
@@ -195,7 +194,7 @@ test('ExpandDTOAttributionsProcessor', function () {
     // array 空类型
     $property = $fnFindPropertyByName('arrayEmptyType');
     expect($property->type)->toBe('array')
-        ->and($property->items->type)->toBe(\OpenApi\Generator::UNDEFINED);
+        ->and($property->items->type)->toBe(Generator::UNDEFINED);
 
     // array 对象
     $property = $fnFindPropertyByName('children');
@@ -205,7 +204,7 @@ test('ExpandDTOAttributionsProcessor', function () {
     // 对象
     $property = $fnFindPropertyByName('child');
     expect($property->type)->toBe('object')
-        ->and($property->_context->type)->toBe('\\' . SchemaDTOChild::class);
+        ->and($property->_context->reflector->getType()->getName())->toBe(SchemaDTOChild::class);
 
     // datetime
     $property = $fnFindPropertyByName('date');
@@ -272,20 +271,15 @@ test('ExpandDTOAttributionsProcessor', function () {
 test('ExpandEnumDescriptionProcessor', function () {
     // 未附加 ExpandEnumDescriptionProcessor 时
     $analysis = TestFactory::analysisFromFiles(['EnumColor.php']);
-    $analysis->process([
-        new \OpenApi\Processors\ExpandEnums(),
-    ]);
-    $schema = $analysis->getSchemaForSource(EnumColor::class);
+    swagger_processor_analyse(\OpenApi\Processors\ExpandEnums::class, $analysis);
+    $schema = $analysis->getAnnotationForSource(EnumColor::class);
     expect($schema->enum)->toBe(['red', 'green', 'blue'])
         ->and($schema->description)->toBe('颜色枚举');
 
     // 附加 ExpandEnumDescriptionProcessor 时
     $analysis = TestFactory::analysisFromFiles(['EnumColor.php']);
-    $analysis->process([
-        new \OpenApi\Processors\ExpandEnums(),
-        new ExpandEnumDescriptionProcessor(),
-    ]);
-    $schema = $analysis->getSchemaForSource(EnumColor::class);
+    swagger_processor_analyse([\OpenApi\Processors\ExpandEnums::class, new ExpandEnumDescriptionProcessor()], $analysis);
+    $schema = $analysis->getAnnotationForSource(EnumColor::class);
     expect($schema->enum)->toBe(['red', 'green', 'blue'])
         ->and($schema->description)->toBe(implode("\n", [
             '颜色枚举',
@@ -296,11 +290,8 @@ test('ExpandEnumDescriptionProcessor', function () {
 
     // 附加 ExpandEnumDescriptionProcessor 时，使用指定的 method 获取
     $analysis = TestFactory::analysisFromFiles(['EnumColor.php']);
-    $analysis->process([
-        new \OpenApi\Processors\ExpandEnums(),
-        new ExpandEnumDescriptionProcessor(descriptionMethod: 'getDescription'),
-    ]);
-    $schema = $analysis->getSchemaForSource(EnumColor::class);
+    swagger_processor_analyse([\OpenApi\Processors\ExpandEnums::class, new ExpandEnumDescriptionProcessor(descriptionMethod: 'getDescription')], $analysis);
+    $schema = $analysis->getAnnotationForSource(EnumColor::class);
     expect($schema->enum)->toBe(['red', 'green', 'blue'])
         ->and($schema->description)->toBe(implode("\n", [
             '颜色枚举',
@@ -311,11 +302,8 @@ test('ExpandEnumDescriptionProcessor', function () {
 
     // 附加 ExpandEnumDescriptionProcessor 时，使用指定的 method 不存在时
     $analysis = TestFactory::analysisFromFiles(['EnumColor.php']);
-    $analysis->process([
-        new \OpenApi\Processors\ExpandEnums(),
-        new ExpandEnumDescriptionProcessor(descriptionMethod: 'getDescription2'),
-    ]);
-    $schema = $analysis->getSchemaForSource(EnumColor::class);
+    swagger_processor_analyse([\OpenApi\Processors\ExpandEnums::class, new ExpandEnumDescriptionProcessor(descriptionMethod: 'getDescription2')], $analysis);
+    $schema = $analysis->getAnnotationForSource(EnumColor::class);
     expect($schema->enum)->toBe(['red', 'green', 'blue'])
         ->and($schema->description)->toBe(implode("\n", [
             '颜色枚举',
@@ -332,12 +320,10 @@ test('ExpandEloquentModelProcessor', function () {
         'SchemaEloquentVisibleModel.php',
         'SchemaEloquentAbsModel.php',
     ]);
-    $analysis->process([
-        new ExpandEloquentModelProcessor(),
-    ]);
+    swagger_processor_analyse(ExpandEloquentModelProcessor::class, $analysis);
 
     $fnGetData = function (string $className) use ($analysis) {
-        $schema = $analysis->getSchemaForSource($className);
+        $schema = $analysis->getAnnotationForSource($className);
         $data = [];
         foreach ($schema->properties as $property) {
             $data[] = [
@@ -371,12 +357,9 @@ test('ExpandEloquentModelProcessor', function () {
 test('XDiscriminatorProcessor', function () {
     $analysis = TestFactory::analysisFromFiles(['ExampleDiscriminator/CreateOrderForm.php']);
 
-    $analysis->process([
-        new ExpandDTOAttributionsProcessor(),
-        new XDiscriminatorProcessor(),
-    ]);
+    swagger_processor_analyse([ExpandDTOAttributionsProcessor::class, XDiscriminatorProcessor::class], $analysis);
 
-    $schema = $analysis->getSchemaForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\CreateOrderForm::class);
+    $schema = $analysis->getAnnotationForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\CreateOrderForm::class);
     expect($schema)->not->toBeNull()
         ->and($schema->oneOf)->not->toBe(\OpenApi\Generator::UNDEFINED)
         ->toBeArray()
@@ -389,21 +372,17 @@ test('XDiscriminatorProcessor', function () {
         ]);
 
     // 验证子 Schema 存在
-    expect($analysis->getSchemaForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\CreateOrderFormOrderDataNormal::class))->not->toBeNull()
-        ->and($analysis->getSchemaForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\CreateOrderFormOrderDataExpress::class))->not->toBeNull();
+    expect($analysis->getAnnotationForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\CreateOrderFormOrderDataNormal::class))->not->toBeNull()
+        ->and($analysis->getAnnotationForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\CreateOrderFormOrderDataExpress::class))->not->toBeNull();
 });
 
 test('XDiscriminatorProcessor for Response', function () {
     $analysis = TestFactory::analysisFromFiles(['ExampleDiscriminator/CreateOrderForm.php']);
 
-    $analysis->process([
-        new ExpandDTOAttributionsProcessor(),
-        new XSchemaResponseProcessor(),
-        new XDiscriminatorProcessor(),
-    ]);
+    swagger_processor_analyse([ExpandDTOAttributionsProcessor::class, XSchemaResponseProcessor::class, XDiscriminatorProcessor::class], $analysis);
 
     // 验证 Response discriminator
-    $responseSchema = $analysis->getSchemaForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\GetOrderResponse::class);
+    $responseSchema = $analysis->getAnnotationForSource(\Tests\Fixtures\Swagger\ExampleDiscriminator\GetOrderResponse::class);
     expect($responseSchema)->not->toBeNull()
         ->and($responseSchema->oneOf)->not->toBe(\OpenApi\Generator::UNDEFINED)
         ->toBeArray()


### PR DESCRIPTION
## 概述

升级 `zircote/swagger-php` 版本约束，从 `>=5.2 <5.5` 升级到 `^6.2`，适配上游 v6 的破坏性变更。

Closes #3

## 破坏性变更

⚠️ **依赖升级**：`zircote/swagger-php` 从 5.x 升级到 `^6.2`，下游用户需同步升级。

## 适配的 v6 破坏性变更

- `Analysis::getSchemaForSource()` → `getAnnotationForSource()`
- `Context::type` → 基于 reflector 的 type resolver API
- `TypesTrait` → `GeneratorAwareInterface` + `getTypeResolver()`
- `Analysis::process()` 移除 → 改用 Generator Pipeline
- `Generator::scan()` 移除 → 改用实例化 `generate()`

## 测试

- ✅ 全量测试通过：325 passed (1326 assertions)
- ✅ snapshot 更新（字段顺序调整、additionalProperties 规范化，无语义变化）
- ✅ swagger 包 PHPStan 干净